### PR TITLE
fix: skip proxy startup without a tty

### DIFF
--- a/internal/zsh/integration_test.go
+++ b/internal/zsh/integration_test.go
@@ -558,3 +558,123 @@ fi
 		t.Errorf("Plugin did not define _do_smart_suggestion. Output:\n%s", string(out))
 	}
 }
+
+func TestProxyNotStartedWithoutTTY(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get wd: %v", err)
+	}
+	projectRoot, err := filepath.Abs(filepath.Join(cwd, "..", ".."))
+	if err != nil {
+		t.Fatalf("Failed to get project root: %v", err)
+	}
+	pluginPath := filepath.Join(projectRoot, "smart-suggestion.plugin.zsh")
+
+	tmpDir := t.TempDir()
+	mockBinPath := filepath.Join(tmpDir, "smart-suggestion-bin")
+	mockLogPath := filepath.Join(tmpDir, "proxy.log")
+	mockBinContent := "#!/bin/sh\nprintf '%s\\n' \"$*\" > \"$MOCK_PROXY_LOG\"\n"
+	if err := os.WriteFile(mockBinPath, []byte(mockBinContent), 0755); err != nil {
+		t.Fatalf("Failed to create mock binary: %v", err)
+	}
+
+	script := fmt.Sprintf("source %q\necho PLUGIN_SOURCED\n", pluginPath)
+	cmd := exec.Command("zsh", "-f", "-i", "-c", script)
+	cmd.Dir = projectRoot
+	cmd.Stdin = strings.NewReader("")
+	cmd.Env = append(os.Environ(),
+		"ZDOTDIR="+tmpDir,
+		"HOME="+tmpDir,
+		"XDG_CACHE_HOME="+tmpDir,
+		"XDG_CONFIG_HOME="+tmpDir,
+		"OPENAI_API_KEY=fake-key",
+		"SMART_SUGGESTION_AI_PROVIDER=openai",
+		"SMART_SUGGESTION_BINARY="+mockBinPath,
+		"SMART_SUGGESTION_AUTO_UPDATE=false",
+		"SMART_SUGGESTION_PROXY_MODE=true",
+		"MOCK_PROXY_LOG="+mockLogPath,
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Command failed with %v: %s", err, string(out))
+	}
+	if !strings.Contains(string(out), "PLUGIN_SOURCED") {
+		t.Fatalf("Plugin did not return control without a TTY. Output:\n%s", string(out))
+	}
+	if _, err := os.Stat(mockLogPath); !os.IsNotExist(err) {
+		t.Fatalf("Proxy started without a TTY; stat error: %v", err)
+	}
+}
+
+func TestProxyStartedWithTTY(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get wd: %v", err)
+	}
+	projectRoot, err := filepath.Abs(filepath.Join(cwd, "..", ".."))
+	if err != nil {
+		t.Fatalf("Failed to get project root: %v", err)
+	}
+	pluginPath := filepath.Join(projectRoot, "smart-suggestion.plugin.zsh")
+
+	tmpDir := t.TempDir()
+	mockBinPath := filepath.Join(tmpDir, "smart-suggestion-bin")
+	mockBinContent := "#!/bin/sh\necho \"PROXY_STARTED:$*\"\n"
+	if err := os.WriteFile(mockBinPath, []byte(mockBinContent), 0755); err != nil {
+		t.Fatalf("Failed to create mock binary: %v", err)
+	}
+
+	script := fmt.Sprintf("source %q\n", pluginPath)
+	cmd := exec.Command("zsh", "-f", "-i", "-c", script)
+	cmd.Dir = projectRoot
+	cmd.Env = append(os.Environ(),
+		"ZDOTDIR="+tmpDir,
+		"HOME="+tmpDir,
+		"XDG_CACHE_HOME="+tmpDir,
+		"XDG_CONFIG_HOME="+tmpDir,
+		"OPENAI_API_KEY=fake-key",
+		"SMART_SUGGESTION_AI_PROVIDER=openai",
+		"SMART_SUGGESTION_BINARY="+mockBinPath,
+		"SMART_SUGGESTION_AUTO_UPDATE=false",
+		"SMART_SUGGESTION_PROXY_MODE=true",
+	)
+
+	terminal, err := pty.Start(cmd)
+	if err != nil {
+		t.Fatalf("Failed to start zsh with a TTY: %v", err)
+	}
+	defer terminal.Close()
+
+	outputCh := make(chan string, 1)
+	go func() {
+		var output bytes.Buffer
+		buf := make([]byte, 1024)
+		for {
+			n, readErr := terminal.Read(buf)
+			if n > 0 {
+				output.Write(buf[:n])
+			}
+			if readErr != nil {
+				outputCh <- output.String()
+				return
+			}
+		}
+	}()
+
+	var output string
+	select {
+	case output = <-outputCh:
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatal("Timed out waiting for proxy to start")
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("Proxy process failed: %v. Output:\n%s", err, output)
+	}
+
+	if !strings.Contains(output, "PROXY_STARTED:proxy --scrollback-lines 100") {
+		t.Fatalf("Proxy did not start with a TTY. Output:\n%s", output)
+	}
+}

--- a/internal/zsh/integration_test.go
+++ b/internal/zsh/integration_test.go
@@ -579,7 +579,7 @@ func TestProxyNotStartedWithoutTTY(t *testing.T) {
 	}
 
 	script := fmt.Sprintf("source %q\necho PLUGIN_SOURCED\n", pluginPath)
-	cmd := exec.Command("zsh", "-f", "-i", "-c", script)
+	cmd := exec.CommandContext(t.Context(), "zsh", "-f", "-i", "-c", script)
 	cmd.Dir = projectRoot
 	cmd.Stdin = strings.NewReader("")
 	cmd.Env = append(os.Environ(),
@@ -593,6 +593,10 @@ func TestProxyNotStartedWithoutTTY(t *testing.T) {
 		"SMART_SUGGESTION_AUTO_UPDATE=false",
 		"SMART_SUGGESTION_PROXY_MODE=true",
 		"MOCK_PROXY_LOG="+mockLogPath,
+		"TMUX=",
+		"KITTY_LISTEN_ON=",
+		"GHOSTTY_RESOURCES_DIR=",
+		"SMART_SUGGESTION_PROXY_ACTIVE=",
 	)
 
 	out, err := cmd.CombinedOutput()
@@ -626,7 +630,7 @@ func TestProxyStartedWithTTY(t *testing.T) {
 	}
 
 	script := fmt.Sprintf("source %q\n", pluginPath)
-	cmd := exec.Command("zsh", "-f", "-i", "-c", script)
+	cmd := exec.CommandContext(t.Context(), "zsh", "-f", "-i", "-c", script)
 	cmd.Dir = projectRoot
 	cmd.Env = append(os.Environ(),
 		"ZDOTDIR="+tmpDir,
@@ -638,6 +642,10 @@ func TestProxyStartedWithTTY(t *testing.T) {
 		"SMART_SUGGESTION_BINARY="+mockBinPath,
 		"SMART_SUGGESTION_AUTO_UPDATE=false",
 		"SMART_SUGGESTION_PROXY_MODE=true",
+		"TMUX=",
+		"KITTY_LISTEN_ON=",
+		"GHOSTTY_RESOURCES_DIR=",
+		"SMART_SUGGESTION_PROXY_ACTIVE=",
 	)
 
 	terminal, err := pty.Start(cmd)

--- a/smart-suggestion.plugin.zsh
+++ b/smart-suggestion.plugin.zsh
@@ -82,7 +82,7 @@ else
 fi
 
 function _run_smart_suggestion_proxy() {
-    if [[ $- == *i* ]]; then
+    if [[ $- == *i* && -t 0 ]]; then
         exec "$SMART_SUGGESTION_BINARY" proxy --scrollback-lines "$SMART_SUGGESTION_SCROLLBACK_LINES"
     fi
 }


### PR DESCRIPTION
## What changed

Require an interactive shell to have a TTY on standard input before replacing it with the smart-suggestion proxy.

Terminal-backed interactive sessions continue to start the proxy normally, while interactive shells launched without a TTY can return control to their caller.

## Why

Some desktop hosts start an interactive shell without attaching a TTY while synchronously importing the shell environment. When this plugin was sourced in that context, it replaced the shell with the long-running proxy process. The caller then waited indefinitely for the shell command to finish, preventing its user interface from becoming available.

The interactive-shell flag alone does not guarantee that the shell is attached to a terminal, so proxy startup now also checks standard input for a TTY.
