### PR TITLE
fix: silence usage on error and preserve user input with new prompt line

### DIFF
--- a/cmd/smart-suggestion/main.go
+++ b/cmd/smart-suggestion/main.go
@@ -277,9 +277,11 @@ func writeSuggestion(outputFile string, suggestion string) error {
 
 func buildRootCmd() *cobra.Command {
 	var rootCmd = &cobra.Command{
-		Use:   "smart-suggestion",
-		Short: "AI-powered smart suggestions for shell commands",
-		RunE:  runSuggest,
+		Use:           "smart-suggestion",
+		Short:         "AI-powered smart suggestions for shell commands",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE:          runSuggest,
 	}
 
 	rootCmd.Flags().StringVarP(&providerName, "provider", "p", "", "AI provider (openai, azure_openai, anthropic, gemini)")

--- a/cmd/smart-suggestion/main_test.go
+++ b/cmd/smart-suggestion/main_test.go
@@ -570,6 +570,12 @@ func TestBuildRootCmd(t *testing.T) {
 	if cmd.Use != "smart-suggestion" {
 		t.Fatalf("expected 'smart-suggestion', got %q", cmd.Use)
 	}
+	if !cmd.SilenceUsage {
+		t.Fatal("expected SilenceUsage to be true")
+	}
+	if !cmd.SilenceErrors {
+		t.Fatal("expected SilenceErrors to be true")
+	}
 
 	subcommands := cmd.Commands()
 	names := make(map[string]bool)
@@ -745,5 +751,43 @@ func TestRunSuggestWriteError(t *testing.T) {
 	err := runSuggest(cmd, nil)
 	if err == nil {
 		t.Fatal("expected error for write failure")
+	}
+}
+
+func TestMainSuccess(t *testing.T) {
+	oldArgs := os.Args
+	oldExit := exitFunc
+	t.Cleanup(func() {
+		os.Args = oldArgs
+		exitFunc = oldExit
+	})
+
+	exitCalled := false
+	exitFunc = func(code int) {
+		exitCalled = true
+	}
+	os.Args = []string{"smart-suggestion", "version"}
+	main()
+	if exitCalled {
+		t.Fatal("expected main to not call exit on version command")
+	}
+}
+
+func TestMainError(t *testing.T) {
+	oldArgs := os.Args
+	oldExit := exitFunc
+	t.Cleanup(func() {
+		os.Args = oldArgs
+		exitFunc = oldExit
+	})
+
+	exitCode := 0
+	exitFunc = func(code int) {
+		exitCode = code
+	}
+	os.Args = []string{"smart-suggestion", "--provider", "invalid_provider", "--input", "test"}
+	main()
+	if exitCode != 1 {
+		t.Fatalf("expected exit code 1, got %d", exitCode)
 	}
 }

--- a/internal/zsh/integration_test.go
+++ b/internal/zsh/integration_test.go
@@ -356,6 +356,39 @@ func TestErrorHandling(t *testing.T) {
 	}
 }
 
+func TestErrorHandlingPreservesInput(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	session, err := spawnZsh()
+	if err != nil {
+		t.Fatalf("Failed to spawn zsh: %v", err)
+	}
+	defer session.Close()
+
+	session.SetMockError("API_ERROR_500")
+
+	// Type something to test preservation of user input
+	session.pty.Write([]byte("echo my_original_input"))
+	time.Sleep(200 * time.Millisecond)
+
+	session.TriggerSuggest()
+
+	_, err = session.Expect("API_ERROR_500", 10*time.Second)
+	if err != nil {
+		t.Fatalf("Error message did not appear: %v. Output: %s", err, session.output.String())
+	}
+
+	// Press Enter to execute the preserved input on the new prompt
+	session.RunCommand("", 2*time.Second)
+
+	_, err = session.Expect("my_original_input", 2*time.Second)
+	if err != nil {
+		t.Fatalf("Original input was not preserved after error. Output: %s", session.output.String())
+	}
+}
+
 func TestTimeoutHandling(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/smart-suggestion.plugin.zsh
+++ b/smart-suggestion.plugin.zsh
@@ -262,12 +262,16 @@ function _do_smart_suggestion() {
 
     if [[ -z "$message" ]]; then
         _zsh_autosuggest_clear
-        local error_msg=$(cat "${SMART_SUGGESTION_CACHE_DIR}/error" 2>/dev/null || echo "No suggestion available at this time. Please try again later.")
+        local error_msg
+        if [[ -s "${SMART_SUGGESTION_CACHE_DIR}/error" ]]; then
+            error_msg=$(<"${SMART_SUGGESTION_CACHE_DIR}/error")
+        fi
+        if [[ -z "${error_msg//[[:space:]]/}" ]]; then
+            error_msg="No suggestion available at this time. Please try again later."
+        fi
 
-        # Use zle -M to display the error message properly
-        zle -M "$error_msg"
-
-        # The user's input remains in BUFFER and CURSOR automatically
+        zle -I
+        print -r -u2 -- "$error_msg"
         return 1
     fi
 


### PR DESCRIPTION
## Description
When the AI provider API returns an error, two issues previously occurred:
1. Cobra printed the entire `Usage:` / `--help` text to stderr because `SilenceUsage` was `false`.
2. The Zsh plugin used `zle -M` to display the error, which corrupted multi-line terminal rendering and erased the error message on the next keystroke.

## Changes
- **CLI (`cmd/smart-suggestion/main.go`)**: Set `SilenceUsage: true` and `SilenceErrors: true` on `rootCmd` to ensure only the clean error message is printed to stderr.
- **Zsh Plugin (`smart-suggestion.plugin.zsh`)**: Replaced `zle -M` with `zle -I` + `print -r -u2` to print the error message directly to the terminal, create a new prompt line beneath it, and preserve the user's original command buffer and cursor position.
- **Tests**:
  - Added unit tests in `cmd/smart-suggestion/main_test.go` for `SilenceUsage`, `SilenceErrors`, and `main()` error exit.
  - Added integration test `TestErrorHandlingPreservesInput` in `internal/zsh/integration_test.go` to verify that the user's input remains intact on the new prompt after an error.