### PR TITLE
feat: support OpenAI responses API via OPENAI_API_TYPE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,5 +122,6 @@ Key variables:
 - **Context Handling**: All code must accept context as a parameter and use `t.Context()` in tests.
 - **Markdown Tables**: All tables in README.md must be column-aligned.
 - **System Prompt**: The system prompt in `main.go` is critical. It defines the contract between the AI and the shell. Any changes to the AI logic must ensure this contract (`=`/`+` prefixes) is maintained.
+- **Strict Environment Variables**: Environment variable names and accepted values must be strict and exact. Do not introduce redundant fallback environment variable names (e.g. only use canonical env var names like `OPENAI_API_TYPE`) or loose/fuzzy value matching. Only accept explicitly documented valid values.
 - **Error Handling**: Errors in the binary are printed to stderr. The Zsh plugin captures stderr to show user-friendly messages.
 - **Dependencies**: Use `go mod` for dependency management.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ The recommended way to configure smart-suggestion is by creating a `config.zsh` 
 ```bash
 # ~/.config/smart-suggestion/config.zsh
 OPENAI_API_KEY="your-openai-api-key"
+OPENAI_API_TYPE="responses" # Optional, "chat_completions" (default) or "responses"
 ```
 
 #### Azure OpenAI
@@ -242,6 +243,13 @@ GEMINI_MODEL="gemini-1.5-pro"  # Default: gemini-2.5-flash
 ```bash
 # ~/.config/smart-suggestion/config.zsh
 SMART_SUGGESTION_HISTORY_LINES="20"  # Default: 10
+```
+
+#### OpenAI API Type
+
+```bash
+# ~/.config/smart-suggestion/config.zsh
+OPENAI_API_TYPE="responses"          # Default: chat_completions, options: chat_completions, responses
 ```
 
 ### View Current Configuration

--- a/cmd/smart-suggestion/main_test.go
+++ b/cmd/smart-suggestion/main_test.go
@@ -91,7 +91,7 @@ func TestRunSuggestMissingFlags(t *testing.T) {
 	dbg = false
 
 	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
+	cmd.SetContext(t.Context())
 
 	err := runSuggest(cmd, nil)
 	if err == nil {
@@ -146,7 +146,7 @@ func TestGetExampleHistory(t *testing.T) {
 
 func TestSelectProvider(t *testing.T) {
 	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
+	cmd.SetContext(t.Context())
 
 	originalProvider := providerName
 	t.Cleanup(func() { providerName = originalProvider })
@@ -646,7 +646,7 @@ func TestRunSuggestSuccess(t *testing.T) {
 	sendContext = false
 
 	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
+	cmd.SetContext(t.Context())
 
 	if err := runSuggest(cmd, nil); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -681,7 +681,7 @@ func TestRunSuggestProviderError(t *testing.T) {
 	dbg = false
 
 	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
+	cmd.SetContext(t.Context())
 
 	err := runSuggest(cmd, nil)
 	if err == nil {
@@ -712,7 +712,7 @@ func TestRunSuggestFetchError(t *testing.T) {
 	sendContext = false
 
 	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
+	cmd.SetContext(t.Context())
 
 	err := runSuggest(cmd, nil)
 	if err == nil {
@@ -746,7 +746,7 @@ func TestRunSuggestWriteError(t *testing.T) {
 	sendContext = false
 
 	cmd := &cobra.Command{}
-	cmd.SetContext(context.Background())
+	cmd.SetContext(t.Context())
 
 	err := runSuggest(cmd, nil)
 	if err == nil {

--- a/internal/provider/openai.go
+++ b/internal/provider/openai.go
@@ -7,12 +7,32 @@ import (
 
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
+	"github.com/openai/openai-go/responses"
 	"github.com/xyenon/smart-suggestion/internal/debug"
 )
 
+type OpenAIAPIType string
+
+const (
+	OpenAIAPITypeChatCompletions OpenAIAPIType = "chat_completions"
+	OpenAIAPITypeResponses       OpenAIAPIType = "responses"
+)
+
 type OpenAIProvider struct {
-	Model  string
-	Client *openai.Client
+	Model   string
+	APIType OpenAIAPIType
+	Client  *openai.Client
+}
+
+func parseOpenAIAPIType(val string) (OpenAIAPIType, error) {
+	switch val {
+	case "", "chat_completions":
+		return OpenAIAPITypeChatCompletions, nil
+	case "responses":
+		return OpenAIAPITypeResponses, nil
+	default:
+		return "", fmt.Errorf("unsupported OPENAI_API_TYPE: %s (valid: chat_completions, responses)", val)
+	}
 }
 
 func NewOpenAIProvider() (*OpenAIProvider, error) {
@@ -31,11 +51,17 @@ func NewOpenAIProvider() (*OpenAIProvider, error) {
 
 	model := envOrDefault(os.Getenv("OPENAI_MODEL"), "gpt-4o-mini")
 
+	apiType, err := parseOpenAIAPIType(os.Getenv("OPENAI_API_TYPE"))
+	if err != nil {
+		return nil, err
+	}
+
 	client := openai.NewClient(options...)
 
 	return &OpenAIProvider{
-		Model:  model,
-		Client: &client,
+		Model:   model,
+		APIType: apiType,
+		Client:  &client,
 	}, nil
 }
 
@@ -46,6 +72,17 @@ func (p *OpenAIProvider) Fetch(ctx context.Context, input string, systemPrompt s
 func (p *OpenAIProvider) FetchWithHistory(ctx context.Context, input string, systemPrompt string, history []Message) (string, error) {
 	logProviderRequest("openai", p.Model, systemPrompt, history, input)
 
+	switch p.APIType {
+	case OpenAIAPITypeResponses:
+		return p.fetchResponses(ctx, input, systemPrompt, history)
+	case OpenAIAPITypeChatCompletions:
+		fallthrough
+	default:
+		return p.fetchChatCompletions(ctx, input, systemPrompt, history)
+	}
+}
+
+func (p *OpenAIProvider) fetchChatCompletions(ctx context.Context, input string, systemPrompt string, history []Message) (string, error) {
 	messages := buildOpenAIChatMessages(systemPrompt, input, history)
 
 	resp, err := p.Client.Chat.Completions.New(
@@ -67,4 +104,37 @@ func (p *OpenAIProvider) FetchWithHistory(ctx context.Context, input string, sys
 	}
 
 	return resp.Choices[0].Message.Content, nil
+}
+
+func (p *OpenAIProvider) fetchResponses(ctx context.Context, input string, systemPrompt string, history []Message) (string, error) {
+	inputItems := buildOpenAIResponseInput(input, history)
+
+	params := responses.ResponseNewParams{
+		Model: responses.ResponsesModel(p.Model),
+		Input: responses.ResponseNewParamsInputUnion{
+			OfInputItemList: inputItems,
+		},
+	}
+	if systemPrompt != "" {
+		params.Instructions = openai.String(systemPrompt)
+	}
+
+	resp, err := p.Client.Responses.New(ctx, params)
+	debug.Log("Received OpenAI response", map[string]any{
+		"response": resp,
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to create response: %w", err)
+	}
+
+	if len(resp.Output) == 0 {
+		return "", fmt.Errorf("no output returned from OpenAI API")
+	}
+
+	outputText := resp.OutputText()
+	if outputText == "" {
+		return "", fmt.Errorf("empty output text returned from OpenAI API")
+	}
+
+	return outputText, nil
 }

--- a/internal/provider/openai_messages.go
+++ b/internal/provider/openai_messages.go
@@ -1,6 +1,9 @@
 package provider
 
-import "github.com/openai/openai-go"
+import (
+	"github.com/openai/openai-go"
+	"github.com/openai/openai-go/responses"
+)
 
 func buildOpenAIChatMessages(systemPrompt string, input string, history []Message) []openai.ChatCompletionMessageParamUnion {
 	messages := []openai.ChatCompletionMessageParamUnion{
@@ -18,4 +21,18 @@ func buildOpenAIChatMessages(systemPrompt string, input string, history []Messag
 
 	messages = append(messages, openai.UserMessage(input))
 	return messages
+}
+
+func buildOpenAIResponseInput(input string, history []Message) responses.ResponseInputParam {
+	items := make(responses.ResponseInputParam, 0, len(history)+1)
+	for _, msg := range history {
+		switch msg.Role {
+		case "user":
+			items = append(items, responses.ResponseInputItemParamOfMessage(msg.Content, responses.EasyInputMessageRoleUser))
+		case "assistant":
+			items = append(items, responses.ResponseInputItemParamOfMessage(msg.Content, responses.EasyInputMessageRoleAssistant))
+		}
+	}
+	items = append(items, responses.ResponseInputItemParamOfMessage(input, responses.EasyInputMessageRoleUser))
+	return items
 }

--- a/internal/provider/openai_test.go
+++ b/internal/provider/openai_test.go
@@ -10,18 +10,58 @@ import (
 
 	"github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
+	"github.com/openai/openai-go/responses"
 )
 
 func TestNewOpenAIProvider(t *testing.T) {
 	os.Setenv("OPENAI_API_KEY", "test-key")
 	defer os.Unsetenv("OPENAI_API_KEY")
 
+	// Default configuration
 	p, err := NewOpenAIProvider()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if p.Model != "gpt-4o-mini" {
 		t.Errorf("expected default model gpt-4o-mini, got %s", p.Model)
+	}
+	if p.APIType != OpenAIAPITypeChatCompletions {
+		t.Errorf("expected default api type chat_completions, got %s", p.APIType)
+	}
+
+	// With OPENAI_API_TYPE=chat_completions
+	os.Setenv("OPENAI_API_TYPE", "chat_completions")
+	p, err = NewOpenAIProvider()
+	os.Unsetenv("OPENAI_API_TYPE")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.APIType != OpenAIAPITypeChatCompletions {
+		t.Errorf("expected api type chat_completions, got %s", p.APIType)
+	}
+
+	// With OPENAI_API_TYPE=responses
+	os.Setenv("OPENAI_API_TYPE", "responses")
+	p, err = NewOpenAIProvider()
+	os.Unsetenv("OPENAI_API_TYPE")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.APIType != OpenAIAPITypeResponses {
+		t.Errorf("expected api type responses, got %s", p.APIType)
+	}
+
+	// With custom base URL and model
+	os.Setenv("OPENAI_BASE_URL", "https://api.custom.com/v1")
+	os.Setenv("OPENAI_MODEL", "gpt-4o")
+	p, err = NewOpenAIProvider()
+	os.Unsetenv("OPENAI_BASE_URL")
+	os.Unsetenv("OPENAI_MODEL")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if p.Model != "gpt-4o" {
+		t.Errorf("expected model gpt-4o, got %s", p.Model)
 	}
 }
 
@@ -31,9 +71,22 @@ func TestNewOpenAIProvider_Errors(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "OPENAI_API_KEY") {
 		t.Errorf("expected api key error, got %v", err)
 	}
+
+	os.Setenv("OPENAI_API_KEY", "test-key")
+	defer os.Unsetenv("OPENAI_API_KEY")
+
+	invalidTypes := []string{"invalid_type", "chat", "response", "chat_completion", "responses "}
+	for _, it := range invalidTypes {
+		os.Setenv("OPENAI_API_TYPE", it)
+		_, err = NewOpenAIProvider()
+		os.Unsetenv("OPENAI_API_TYPE")
+		if err == nil || !strings.Contains(err.Error(), "unsupported OPENAI_API_TYPE") {
+			t.Errorf("expected unsupported OPENAI_API_TYPE error for %q, got %v", it, err)
+		}
+	}
 }
 
-func TestOpenAIProvider_Fetch(t *testing.T) {
+func TestOpenAIProvider_Fetch_ChatCompletions(t *testing.T) {
 	cases := []TestCase{
 		{
 			Name:         "successful command suggestion",
@@ -131,8 +184,9 @@ func TestOpenAIProvider_Fetch(t *testing.T) {
 			)
 
 			p := &OpenAIProvider{
-				Model:  "gpt-4o-mini",
-				Client: &client,
+				Model:   "gpt-4o-mini",
+				APIType: OpenAIAPITypeChatCompletions,
+				Client:  &client,
 			}
 
 			resp, err := p.Fetch(t.Context(), tc.Input, tc.SystemPrompt)
@@ -155,5 +209,209 @@ func TestOpenAIProvider_Fetch(t *testing.T) {
 				t.Errorf("expected output %q, got %q (original response: %q)", tc.ExpectedOutput, got, resp)
 			}
 		})
+	}
+}
+
+type openAITestCase struct {
+	Name           string
+	Input          string
+	SystemPrompt   string
+	History        []Message
+	MockResponse   string
+	MockStatus     int
+	ExpectedOutput string
+	ExpectedError  string
+}
+
+func TestOpenAIProvider_Fetch_Responses(t *testing.T) {
+	cases := []openAITestCase{
+		{
+			Name:         "successful command suggestion",
+			Input:        "how to list files",
+			SystemPrompt: "you are a shell assistant",
+			MockStatus:   http.StatusOK,
+			MockResponse: `{
+				"id": "resp_123",
+				"object": "response",
+				"created_at": 1740000000,
+				"status": "completed",
+				"model": "gpt-4o-mini",
+				"output": [
+					{
+						"id": "msg_123",
+						"type": "message",
+						"status": "completed",
+						"role": "assistant",
+						"content": [
+							{
+								"type": "output_text",
+								"text": "<reasoning>The user wants to list files.</reasoning>=ls -l"
+							}
+						]
+					}
+				],
+				"usage": {
+					"input_tokens": 9,
+					"output_tokens": 12,
+					"total_tokens": 21
+				}
+			}`,
+			ExpectedOutput: "=ls -l",
+		},
+		{
+			Name:         "successful completion suggestion with history",
+			Input:        "ls -",
+			SystemPrompt: "you are a shell assistant",
+			History: []Message{
+				{Role: "user", Content: "hello"},
+				{Role: "assistant", Content: "world"},
+			},
+			MockStatus: http.StatusOK,
+			MockResponse: `{
+				"id": "resp_456",
+				"object": "response",
+				"created_at": 1740000000,
+				"status": "completed",
+				"model": "gpt-4o-mini",
+				"output": [
+					{
+						"id": "msg_456",
+						"type": "message",
+						"status": "completed",
+						"role": "assistant",
+						"content": [
+							{
+								"type": "output_text",
+								"text": "<reasoning>The user is typing ls and wants completion.</reasoning>+la"
+							}
+						]
+					}
+				]
+			}`,
+			ExpectedOutput: "+la",
+		},
+		{
+			Name:          "API error",
+			Input:         "test",
+			SystemPrompt:  "test",
+			MockStatus:    http.StatusBadRequest,
+			MockResponse:  `{"error": {"message": "invalid api key"}}`,
+			ExpectedError: "failed to create response",
+		},
+		{
+			Name:          "malformed JSON",
+			Input:         "test",
+			SystemPrompt:  "test",
+			MockStatus:    http.StatusOK,
+			MockResponse:  `{"output": [{"content": [{"text": "broken`,
+			ExpectedError: "failed to create response",
+		},
+		{
+			Name:         "no output",
+			Input:        "test",
+			SystemPrompt: "test",
+			MockStatus:   http.StatusOK,
+			MockResponse: `{
+				"id": "resp_789",
+				"object": "response",
+				"status": "completed",
+				"output": []
+			}`,
+			ExpectedError: "no output returned from OpenAI API",
+		},
+		{
+			Name:         "empty output text",
+			Input:        "test",
+			SystemPrompt: "test",
+			MockStatus:   http.StatusOK,
+			MockResponse: `{
+				"id": "resp_000",
+				"object": "response",
+				"status": "completed",
+				"output": [
+					{
+						"id": "msg_000",
+						"type": "message",
+						"status": "completed",
+						"role": "assistant",
+						"content": [
+							{
+								"type": "output_text",
+								"text": ""
+							}
+						]
+					}
+				]
+			}`,
+			ExpectedError: "empty output text returned from OpenAI API",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.MockStatus)
+				fmt.Fprint(w, tc.MockResponse)
+			}))
+			defer server.Close()
+
+			client := openai.NewClient(
+				option.WithAPIKey("test-key"),
+				option.WithBaseURL(server.URL),
+			)
+
+			p := &OpenAIProvider{
+				Model:   "gpt-4o-mini",
+				APIType: OpenAIAPITypeResponses,
+				Client:  &client,
+			}
+
+			var resp string
+			var err error
+			if tc.History != nil {
+				resp, err = p.FetchWithHistory(t.Context(), tc.Input, tc.SystemPrompt, tc.History)
+			} else {
+				resp, err = p.Fetch(t.Context(), tc.Input, tc.SystemPrompt)
+			}
+
+			if tc.ExpectedError != "" {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tc.ExpectedError)
+				} else if !strings.Contains(err.Error(), tc.ExpectedError) {
+					t.Errorf("expected error containing %q, got %q", tc.ExpectedError, err.Error())
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			got := ParseAndExtractCommand(resp)
+			if got != tc.ExpectedOutput {
+				t.Errorf("expected output %q, got %q (original response: %q)", tc.ExpectedOutput, got, resp)
+			}
+		})
+	}
+}
+
+func TestBuildOpenAIResponseInput(t *testing.T) {
+	history := []Message{
+		{Role: "user", Content: "cmd 1"},
+		{Role: "assistant", Content: "result 1"},
+		{Role: "system", Content: "ignore this"},
+	}
+	input := "cmd 2"
+
+	items := buildOpenAIResponseInput(input, history)
+	if len(items) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(items))
+	}
+
+	// Verify items are valid ResponseInputParam
+	param := responses.ResponseInputParam(items)
+	if len(param) != 3 {
+		t.Fatalf("expected 3 items in param, got %d", len(param))
 	}
 }

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -828,3 +828,58 @@ func TestDownloadFile_StatusError(t *testing.T) {
 		t.Errorf("expected download failure error, got %v", err)
 	}
 }
+
+func TestSafeJoinPath_Invalid(t *testing.T) {
+	dest := t.TempDir()
+	_, err := safeJoinPath(dest, ".")
+	if err == nil {
+		t.Error("expected error for '.'")
+	}
+	_, err = safeJoinPath(dest, "/")
+	if err == nil {
+		t.Error("expected error for '/'")
+	}
+}
+
+func TestRollbackFromBackup_NotExist(t *testing.T) {
+	err := rollbackFromBackup("/nonexistent/file")
+	if err == nil {
+		t.Error("expected error for nonexistent file backup")
+	}
+}
+
+func TestReplaceWithBackup_Success(t *testing.T) {
+	tempDir := t.TempDir()
+	target := filepath.Join(tempDir, "target.txt")
+	source := filepath.Join(tempDir, "source.txt")
+	os.WriteFile(target, []byte("target"), 0644)
+	os.WriteFile(source, []byte("source"), 0644)
+
+	cleanup, err := replaceWithBackup(target, source, 0644)
+	if err != nil {
+		t.Fatalf("replaceWithBackup failed: %v", err)
+	}
+	cleanup()
+
+	data, _ := os.ReadFile(target)
+	if string(data) != "source" {
+		t.Errorf("expected source, got %q", string(data))
+	}
+}
+
+func TestRollbackFromBackup_Success(t *testing.T) {
+	tempDir := t.TempDir()
+	target := filepath.Join(tempDir, "file.txt")
+	backup := target + ".backup"
+	os.WriteFile(target, []byte("broken"), 0644)
+	os.WriteFile(backup, []byte("original"), 0644)
+
+	err := rollbackFromBackup(target)
+	if err != nil {
+		t.Fatalf("rollbackFromBackup failed: %v", err)
+	}
+	data, _ := os.ReadFile(target)
+	if string(data) != "original" {
+		t.Errorf("expected original, got %q", string(data))
+	}
+}


### PR DESCRIPTION
## Description

This PR introduces support for OpenAI's new Responses API (`/v1/responses`) and adds an environment variable `OPENAI_API_TYPE` to configure whether to use the Chat Completions API or the Responses API.

## Changes

- Added `OPENAI_API_TYPE` configuration supporting `chat_completions` (default) and `responses`.
- Added strict environment variable validation rejecting any unsupported/fuzzy values.
- Added `buildOpenAIResponseInput` to construct `ResponseInputParam` for Responses API requests.
- Added `fetchResponses` method to `OpenAIProvider` to query the Responses API and extract command suggestions.
- Added comprehensive unit tests for Responses API and strict `OPENAI_API_TYPE` parsing.
- Updated documentation in `README.md` and added the strict environment variable convention to `AGENTS.md`.