### PR TITLE
feat: add Herdr native scrollback integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,10 +37,11 @@ The project consists of three main components:
 To provide relevant suggestions, the tool gathers context from the user's shell environment. The **Scrollback** (what is currently visible on screen) is acquired using the following priority strategies:
 
 1.  **Tmux**: Checks for `TMUX` env var. Uses `tmux capture-pane -pS -`.
-2.  **Kitty**: Checks for `KITTY_LISTEN_ON` env var. Uses `kitten @ get-text --extent all`.
-3.  **Session Proxy Log**: If running in the tool's own proxy mode (with a session ID), reads from the session-specific log file.
-4.  **Default Proxy Log**: Reads from the global proxy log file.
-5.  **GNU Screen**: Checks for `STY` env var. Uses `screen -X hardcopy`.
+2.  **Herdr**: Checks for `HERDR_ENV=1`. Uses `herdr pane read $HERDR_PANE_ID --source recent-unwrapped`.
+3.  **Kitty**: Checks for `KITTY_LISTEN_ON` env var. Uses `kitten @ get-text --extent all`.
+4.  **Session Proxy Log**: If running in the tool's own proxy mode (with a session ID), reads from the session-specific log file.
+5.  **Default Proxy Log**: Reads from the global proxy log file.
+6.  **GNU Screen**: Checks for `STY` env var. Uses `screen -X hardcopy`.
 
 It also captures:
 - **Shell History**: Passed via environment variable `SMART_SUGGESTION_HISTORY`.

--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ Smart Suggestion automatically detects and uses native scrollback APIs for suppo
 | Terminal       | Detection                       | Method                         |
 |----------------|---------------------------------|--------------------------------|
 | **Tmux**       | `TMUX` env var                  | `tmux capture-pane`            |
+| **Herdr**      | `HERDR_ENV=1`                   | `herdr pane read`              |
 | **Kitty**      | `KITTY_LISTEN_ON` env var       | `kitten @ get-text`            |
 | **Ghostty**    | `GHOSTTY_RESOURCES_DIR` env var | `write_screen_file` keybind    |
 | **GNU Screen** | `STY` env var                   | `screen -X hardcopy`           |

--- a/internal/shellcontext/context.go
+++ b/internal/shellcontext/context.go
@@ -317,6 +317,18 @@ func readLatestProxyContent(logFile string, maxLines int) (string, error) {
 	return strings.Join(lines, "\n"), nil
 }
 
+// herdrRecentLinesUnlimited is passed as --lines when scrollbackLines <= 0.
+// Herdr recent sources default to 80 rows if --lines is omitted, which would
+// not match the rest of smart-suggestion treating 0 as unlimited.
+const herdrRecentLinesUnlimited = 100000
+
+func herdrBinary() string {
+	if bin := os.Getenv("HERDR_BIN_PATH"); bin != "" {
+		return bin
+	}
+	return "herdr"
+}
+
 func getHerdrScrollback(scrollbackLines int) (string, error) {
 	if os.Getenv("HERDR_ENV") != "1" {
 		return "", fmt.Errorf("not in a herdr session")
@@ -327,11 +339,12 @@ func getHerdrScrollback(scrollbackLines int) (string, error) {
 		return "", fmt.Errorf("HERDR_PANE_ID is empty")
 	}
 
-	args := []string{"pane", "read", paneID, "--source", "recent-unwrapped"}
-	if scrollbackLines > 0 {
-		args = append(args, "--lines", strconv.Itoa(scrollbackLines))
+	lines := scrollbackLines
+	if lines <= 0 {
+		lines = herdrRecentLinesUnlimited
 	}
-	cmd := execCommand("herdr", args...)
+	args := []string{"pane", "read", paneID, "--source", "recent-unwrapped", "--lines", strconv.Itoa(lines)}
+	cmd := execCommand(herdrBinary(), args...)
 	output, err := cmd.Output()
 	if err != nil {
 		debug.Log("Failed to get herdr scrollback", map[string]any{"error": err.Error()})

--- a/internal/shellcontext/context.go
+++ b/internal/shellcontext/context.go
@@ -207,7 +207,13 @@ func doGetScrollback(scrollbackLines int, scrollbackFile string) (string, error)
 		debug.Log("Failed to get tmux scrollback", map[string]any{"error": err.Error()})
 	}
 
-	// 3. Kitty
+	// 3. Herdr
+	content, err := getHerdrScrollback(scrollbackLines)
+	if err == nil {
+		return content, nil
+	}
+
+	// 4. Kitty
 	if os.Getenv("KITTY_LISTEN_ON") != "" {
 		cmd := execCommand("kitten", "@", "get-text", "--extent", "all")
 		output, err := cmd.Output()
@@ -217,7 +223,7 @@ func doGetScrollback(scrollbackLines int, scrollbackFile string) (string, error)
 		debug.Log("Failed to get kitty scrollback", map[string]any{"error": err.Error()})
 	}
 
-	// 4. Session proxy log
+	// 5. Session proxy log
 	currentSessionID := session.GetCurrentSessionID()
 	if currentSessionID != "" {
 		sessionLogFile := session.GetSessionBasedLogFile(defaultProxyLogFile, currentSessionID)
@@ -232,8 +238,8 @@ func doGetScrollback(scrollbackLines int, scrollbackFile string) (string, error)
 		})
 	}
 
-	// 5. Default proxy log
-	content, err := readLatestProxyContent(defaultProxyLogFile, scrollbackLines)
+	// 6. Default proxy log
+	content, err = readLatestProxyContent(defaultProxyLogFile, scrollbackLines)
 	if err == nil {
 		return content, nil
 	}
@@ -242,19 +248,19 @@ func doGetScrollback(scrollbackLines int, scrollbackFile string) (string, error)
 		"file":  defaultProxyLogFile,
 	})
 
-	// 6. GNU Screen
+	// 7. GNU Screen
 	content, err = getScreenScrollback()
 	if err == nil {
 		return content, nil
 	}
 
-	// 7. tput fallback
+	// 8. tput fallback
 	content, err = getTerminalScrollbackWithTput()
 	if err == nil {
 		return content, nil
 	}
 
-	return "", fmt.Errorf("no scrollback available - not in tmux/screen session and no proxy log found")
+	return "", fmt.Errorf("no scrollback available - not in tmux/screen/herdr session and no proxy log found")
 }
 
 func readLatestLines(content string, maxLines int) (string, error) {
@@ -309,6 +315,30 @@ func readLatestProxyContent(logFile string, maxLines int) (string, error) {
 	}
 
 	return strings.Join(lines, "\n"), nil
+}
+
+func getHerdrScrollback(scrollbackLines int) (string, error) {
+	if os.Getenv("HERDR_ENV") != "1" {
+		return "", fmt.Errorf("not in a herdr session")
+	}
+
+	paneID := os.Getenv("HERDR_PANE_ID")
+	if paneID == "" {
+		return "", fmt.Errorf("HERDR_PANE_ID is empty")
+	}
+
+	args := []string{"pane", "read", paneID, "--source", "recent-unwrapped"}
+	if scrollbackLines > 0 {
+		args = append(args, "--lines", strconv.Itoa(scrollbackLines))
+	}
+	cmd := execCommand("herdr", args...)
+	output, err := cmd.Output()
+	if err != nil {
+		debug.Log("Failed to get herdr scrollback", map[string]any{"error": err.Error()})
+		return "", fmt.Errorf("failed to capture herdr scrollback: %w", err)
+	}
+
+	return strings.TrimSpace(string(output)), nil
 }
 
 func getScreenScrollback() (string, error) {

--- a/internal/shellcontext/context_test.go
+++ b/internal/shellcontext/context_test.go
@@ -397,15 +397,18 @@ func TestDoGetScrollbackTmux(t *testing.T) {
 func TestDoGetScrollbackKitty(t *testing.T) {
 	oldTmux := os.Getenv("TMUX")
 	oldKitty := os.Getenv("KITTY_LISTEN_ON")
+	oldHerdrEnv := os.Getenv("HERDR_ENV")
 	oldExec := execCommand
 	t.Cleanup(func() {
 		os.Setenv("TMUX", oldTmux)
 		os.Setenv("KITTY_LISTEN_ON", oldKitty)
+		os.Setenv("HERDR_ENV", oldHerdrEnv)
 		execCommand = oldExec
 	})
 
 	os.Setenv("TMUX", "")
 	os.Setenv("KITTY_LISTEN_ON", "unix:/tmp/kitty")
+	os.Setenv("HERDR_ENV", "")
 	execCommand = func(name string, args ...string) *exec.Cmd {
 		if name == "kitten" {
 			return exec.Command("echo", "kitty scrollback")
@@ -422,16 +425,187 @@ func TestDoGetScrollbackKitty(t *testing.T) {
 	}
 }
 
+func TestDoGetScrollbackHerdr(t *testing.T) {
+	oldTmux := os.Getenv("TMUX")
+	oldKitty := os.Getenv("KITTY_LISTEN_ON")
+	oldHerdrEnv := os.Getenv("HERDR_ENV")
+	oldHerdrPane := os.Getenv("HERDR_PANE_ID")
+	oldExec := execCommand
+	t.Cleanup(func() {
+		os.Setenv("TMUX", oldTmux)
+		os.Setenv("KITTY_LISTEN_ON", oldKitty)
+		os.Setenv("HERDR_ENV", oldHerdrEnv)
+		os.Setenv("HERDR_PANE_ID", oldHerdrPane)
+		execCommand = oldExec
+	})
+
+	os.Setenv("TMUX", "")
+	os.Setenv("KITTY_LISTEN_ON", "")
+	os.Setenv("HERDR_ENV", "1")
+	os.Setenv("HERDR_PANE_ID", "w1:p1")
+
+	var gotArgs []string
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		if name == "herdr" {
+			gotArgs = append([]string{name}, args...)
+			return exec.Command("echo", "herdr scrollback")
+		}
+		return exec.Command("false")
+	}
+
+	content, err := doGetScrollback(10, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(content, "herdr scrollback") {
+		t.Fatalf("expected herdr content, got %q", content)
+	}
+
+	wantArgs := []string{"herdr", "pane", "read", "w1:p1", "--source", "recent-unwrapped", "--lines", "10"}
+	if strings.Join(gotArgs, " ") != strings.Join(wantArgs, " ") {
+		t.Fatalf("expected herdr args %q, got %q", wantArgs, gotArgs)
+	}
+}
+
+func TestDoGetScrollbackHerdrBeforeKitty(t *testing.T) {
+	oldTmux := os.Getenv("TMUX")
+	oldKitty := os.Getenv("KITTY_LISTEN_ON")
+	oldHerdrEnv := os.Getenv("HERDR_ENV")
+	oldHerdrPane := os.Getenv("HERDR_PANE_ID")
+	oldExec := execCommand
+	t.Cleanup(func() {
+		os.Setenv("TMUX", oldTmux)
+		os.Setenv("KITTY_LISTEN_ON", oldKitty)
+		os.Setenv("HERDR_ENV", oldHerdrEnv)
+		os.Setenv("HERDR_PANE_ID", oldHerdrPane)
+		execCommand = oldExec
+	})
+
+	os.Setenv("TMUX", "")
+	os.Setenv("KITTY_LISTEN_ON", "unix:/tmp/kitty")
+	os.Setenv("HERDR_ENV", "1")
+	os.Setenv("HERDR_PANE_ID", "w1:p1")
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		switch name {
+		case "herdr":
+			return exec.Command("echo", "herdr scrollback")
+		case "kitten":
+			return exec.Command("echo", "kitty scrollback")
+		default:
+			return exec.Command("false")
+		}
+	}
+
+	content, err := doGetScrollback(10, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(content, "herdr scrollback") {
+		t.Fatalf("expected herdr to take priority over kitty, got %q", content)
+	}
+	if strings.Contains(content, "kitty scrollback") {
+		t.Fatalf("did not expect kitty content when herdr is available, got %q", content)
+	}
+}
+
+func TestGetHerdrScrollbackNotInSession(t *testing.T) {
+	oldHerdrEnv := os.Getenv("HERDR_ENV")
+	oldHerdrPane := os.Getenv("HERDR_PANE_ID")
+	t.Cleanup(func() {
+		os.Setenv("HERDR_ENV", oldHerdrEnv)
+		os.Setenv("HERDR_PANE_ID", oldHerdrPane)
+	})
+
+	os.Setenv("HERDR_ENV", "")
+	os.Setenv("HERDR_PANE_ID", "w1:p1")
+	if _, err := getHerdrScrollback(10); err == nil {
+		t.Fatal("expected error when HERDR_ENV is not set")
+	}
+
+	os.Setenv("HERDR_ENV", "true")
+	if _, err := getHerdrScrollback(10); err == nil {
+		t.Fatal("expected error when HERDR_ENV is not exactly 1")
+	}
+
+	os.Setenv("HERDR_ENV", "1")
+	os.Setenv("HERDR_PANE_ID", "")
+	if _, err := getHerdrScrollback(10); err == nil {
+		t.Fatal("expected error when HERDR_PANE_ID is empty")
+	}
+}
+
+func TestGetHerdrScrollbackCommandError(t *testing.T) {
+	oldHerdrEnv := os.Getenv("HERDR_ENV")
+	oldHerdrPane := os.Getenv("HERDR_PANE_ID")
+	oldExec := execCommand
+	t.Cleanup(func() {
+		os.Setenv("HERDR_ENV", oldHerdrEnv)
+		os.Setenv("HERDR_PANE_ID", oldHerdrPane)
+		execCommand = oldExec
+	})
+
+	os.Setenv("HERDR_ENV", "1")
+	os.Setenv("HERDR_PANE_ID", "w1:p1")
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		return exec.Command("false")
+	}
+
+	if _, err := getHerdrScrollback(10); err == nil {
+		t.Fatal("expected error when herdr command fails")
+	}
+}
+
+func TestGetHerdrScrollbackOmitsLinesWhenZero(t *testing.T) {
+	oldHerdrEnv := os.Getenv("HERDR_ENV")
+	oldHerdrPane := os.Getenv("HERDR_PANE_ID")
+	oldExec := execCommand
+	t.Cleanup(func() {
+		os.Setenv("HERDR_ENV", oldHerdrEnv)
+		os.Setenv("HERDR_PANE_ID", oldHerdrPane)
+		execCommand = oldExec
+	})
+
+	os.Setenv("HERDR_ENV", "1")
+	os.Setenv("HERDR_PANE_ID", "w1:p1")
+
+	var gotArgs []string
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		if name == "herdr" {
+			gotArgs = append([]string{name}, args...)
+			return exec.Command("echo", "herdr scrollback")
+		}
+		return exec.Command("false")
+	}
+
+	content, err := getHerdrScrollback(0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if content != "herdr scrollback" {
+		t.Fatalf("expected herdr content, got %q", content)
+	}
+
+	for _, arg := range gotArgs {
+		if arg == "--lines" {
+			t.Fatalf("did not expect --lines when scrollbackLines is 0, got %q", gotArgs)
+		}
+	}
+}
+
 func TestGetScrollbackError(t *testing.T) {
 	oldTmux := os.Getenv("TMUX")
 	oldKitty := os.Getenv("KITTY_LISTEN_ON")
 	oldSTY := os.Getenv("STY")
+	oldHerdrEnv := os.Getenv("HERDR_ENV")
+	oldHerdrPane := os.Getenv("HERDR_PANE_ID")
 	oldSessionID := os.Getenv("SMART_SUGGESTION_SESSION_ID")
 	oldExec := execCommand
 	t.Cleanup(func() {
 		os.Setenv("TMUX", oldTmux)
 		os.Setenv("KITTY_LISTEN_ON", oldKitty)
 		os.Setenv("STY", oldSTY)
+		os.Setenv("HERDR_ENV", oldHerdrEnv)
+		os.Setenv("HERDR_PANE_ID", oldHerdrPane)
 		os.Setenv("SMART_SUGGESTION_SESSION_ID", oldSessionID)
 		execCommand = oldExec
 	})
@@ -439,6 +613,8 @@ func TestGetScrollbackError(t *testing.T) {
 	os.Setenv("TMUX", "")
 	os.Setenv("KITTY_LISTEN_ON", "")
 	os.Setenv("STY", "")
+	os.Setenv("HERDR_ENV", "")
+	os.Setenv("HERDR_PANE_ID", "")
 	os.Setenv("SMART_SUGGESTION_SESSION_ID", "")
 	execCommand = func(name string, args ...string) *exec.Cmd {
 		return exec.Command("false")

--- a/internal/shellcontext/context_test.go
+++ b/internal/shellcontext/context_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -430,12 +431,14 @@ func TestDoGetScrollbackHerdr(t *testing.T) {
 	oldKitty := os.Getenv("KITTY_LISTEN_ON")
 	oldHerdrEnv := os.Getenv("HERDR_ENV")
 	oldHerdrPane := os.Getenv("HERDR_PANE_ID")
+	oldHerdrBin := os.Getenv("HERDR_BIN_PATH")
 	oldExec := execCommand
 	t.Cleanup(func() {
 		os.Setenv("TMUX", oldTmux)
 		os.Setenv("KITTY_LISTEN_ON", oldKitty)
 		os.Setenv("HERDR_ENV", oldHerdrEnv)
 		os.Setenv("HERDR_PANE_ID", oldHerdrPane)
+		os.Setenv("HERDR_BIN_PATH", oldHerdrBin)
 		execCommand = oldExec
 	})
 
@@ -443,6 +446,7 @@ func TestDoGetScrollbackHerdr(t *testing.T) {
 	os.Setenv("KITTY_LISTEN_ON", "")
 	os.Setenv("HERDR_ENV", "1")
 	os.Setenv("HERDR_PANE_ID", "w1:p1")
+	os.Setenv("HERDR_BIN_PATH", "")
 
 	var gotArgs []string
 	execCommand = func(name string, args ...string) *exec.Cmd {
@@ -472,12 +476,14 @@ func TestDoGetScrollbackHerdrBeforeKitty(t *testing.T) {
 	oldKitty := os.Getenv("KITTY_LISTEN_ON")
 	oldHerdrEnv := os.Getenv("HERDR_ENV")
 	oldHerdrPane := os.Getenv("HERDR_PANE_ID")
+	oldHerdrBin := os.Getenv("HERDR_BIN_PATH")
 	oldExec := execCommand
 	t.Cleanup(func() {
 		os.Setenv("TMUX", oldTmux)
 		os.Setenv("KITTY_LISTEN_ON", oldKitty)
 		os.Setenv("HERDR_ENV", oldHerdrEnv)
 		os.Setenv("HERDR_PANE_ID", oldHerdrPane)
+		os.Setenv("HERDR_BIN_PATH", oldHerdrBin)
 		execCommand = oldExec
 	})
 
@@ -485,6 +491,7 @@ func TestDoGetScrollbackHerdrBeforeKitty(t *testing.T) {
 	os.Setenv("KITTY_LISTEN_ON", "unix:/tmp/kitty")
 	os.Setenv("HERDR_ENV", "1")
 	os.Setenv("HERDR_PANE_ID", "w1:p1")
+	os.Setenv("HERDR_BIN_PATH", "")
 	execCommand = func(name string, args ...string) *exec.Cmd {
 		switch name {
 		case "herdr":
@@ -537,15 +544,18 @@ func TestGetHerdrScrollbackNotInSession(t *testing.T) {
 func TestGetHerdrScrollbackCommandError(t *testing.T) {
 	oldHerdrEnv := os.Getenv("HERDR_ENV")
 	oldHerdrPane := os.Getenv("HERDR_PANE_ID")
+	oldHerdrBin := os.Getenv("HERDR_BIN_PATH")
 	oldExec := execCommand
 	t.Cleanup(func() {
 		os.Setenv("HERDR_ENV", oldHerdrEnv)
 		os.Setenv("HERDR_PANE_ID", oldHerdrPane)
+		os.Setenv("HERDR_BIN_PATH", oldHerdrBin)
 		execCommand = oldExec
 	})
 
 	os.Setenv("HERDR_ENV", "1")
 	os.Setenv("HERDR_PANE_ID", "w1:p1")
+	os.Setenv("HERDR_BIN_PATH", "")
 	execCommand = func(name string, args ...string) *exec.Cmd {
 		return exec.Command("false")
 	}
@@ -555,18 +565,55 @@ func TestGetHerdrScrollbackCommandError(t *testing.T) {
 	}
 }
 
-func TestGetHerdrScrollbackOmitsLinesWhenZero(t *testing.T) {
+func TestGetHerdrScrollbackUsesBinPath(t *testing.T) {
 	oldHerdrEnv := os.Getenv("HERDR_ENV")
 	oldHerdrPane := os.Getenv("HERDR_PANE_ID")
+	oldHerdrBin := os.Getenv("HERDR_BIN_PATH")
 	oldExec := execCommand
 	t.Cleanup(func() {
 		os.Setenv("HERDR_ENV", oldHerdrEnv)
 		os.Setenv("HERDR_PANE_ID", oldHerdrPane)
+		os.Setenv("HERDR_BIN_PATH", oldHerdrBin)
 		execCommand = oldExec
 	})
 
 	os.Setenv("HERDR_ENV", "1")
 	os.Setenv("HERDR_PANE_ID", "w1:p1")
+	os.Setenv("HERDR_BIN_PATH", "/custom/bin/herdr")
+
+	var gotName string
+	execCommand = func(name string, args ...string) *exec.Cmd {
+		gotName = name
+		return exec.Command("echo", "herdr scrollback")
+	}
+
+	content, err := getHerdrScrollback(10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if content != "herdr scrollback" {
+		t.Fatalf("expected herdr content, got %q", content)
+	}
+	if gotName != "/custom/bin/herdr" {
+		t.Fatalf("expected HERDR_BIN_PATH binary, got %q", gotName)
+	}
+}
+
+func TestGetHerdrScrollbackUnlimitedLines(t *testing.T) {
+	oldHerdrEnv := os.Getenv("HERDR_ENV")
+	oldHerdrPane := os.Getenv("HERDR_PANE_ID")
+	oldHerdrBin := os.Getenv("HERDR_BIN_PATH")
+	oldExec := execCommand
+	t.Cleanup(func() {
+		os.Setenv("HERDR_ENV", oldHerdrEnv)
+		os.Setenv("HERDR_PANE_ID", oldHerdrPane)
+		os.Setenv("HERDR_BIN_PATH", oldHerdrBin)
+		execCommand = oldExec
+	})
+
+	os.Setenv("HERDR_ENV", "1")
+	os.Setenv("HERDR_PANE_ID", "w1:p1")
+	os.Setenv("HERDR_BIN_PATH", "")
 
 	var gotArgs []string
 	execCommand = func(name string, args ...string) *exec.Cmd {
@@ -585,10 +632,9 @@ func TestGetHerdrScrollbackOmitsLinesWhenZero(t *testing.T) {
 		t.Fatalf("expected herdr content, got %q", content)
 	}
 
-	for _, arg := range gotArgs {
-		if arg == "--lines" {
-			t.Fatalf("did not expect --lines when scrollbackLines is 0, got %q", gotArgs)
-		}
+	wantArgs := []string{"herdr", "pane", "read", "w1:p1", "--source", "recent-unwrapped", "--lines", strconv.Itoa(herdrRecentLinesUnlimited)}
+	if strings.Join(gotArgs, " ") != strings.Join(wantArgs, " ") {
+		t.Fatalf("expected herdr args %q, got %q", wantArgs, gotArgs)
 	}
 }
 

--- a/internal/zsh/integration_test.go
+++ b/internal/zsh/integration_test.go
@@ -757,6 +757,7 @@ func TestProxyNotStartedInHerdr(t *testing.T) {
 		"KITTY_LISTEN_ON=",
 		"GHOSTTY_RESOURCES_DIR=",
 		"HERDR_ENV=1",
+		"HERDR_PANE_ID=w1:p1",
 		"SMART_SUGGESTION_PROXY_ACTIVE=",
 	)
 
@@ -799,5 +800,83 @@ func TestProxyNotStartedInHerdr(t *testing.T) {
 	}
 	if strings.Contains(output, "PROXY_STARTED") {
 		t.Fatalf("Proxy started in Herdr session. Output:\n%s", output)
+	}
+}
+
+func TestProxyStartedInHerdrWithoutPaneID(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get wd: %v", err)
+	}
+	projectRoot, err := filepath.Abs(filepath.Join(cwd, "..", ".."))
+	if err != nil {
+		t.Fatalf("Failed to get project root: %v", err)
+	}
+	pluginPath := filepath.Join(projectRoot, "smart-suggestion.plugin.zsh")
+
+	tmpDir := t.TempDir()
+	mockBinPath := filepath.Join(tmpDir, "smart-suggestion-bin")
+	mockBinContent := "#!/bin/sh\necho \"PROXY_STARTED:$*\"\n"
+	if err := os.WriteFile(mockBinPath, []byte(mockBinContent), 0755); err != nil {
+		t.Fatalf("Failed to create mock binary: %v", err)
+	}
+
+	script := fmt.Sprintf("source %q\n", pluginPath)
+	cmd := exec.CommandContext(t.Context(), "zsh", "-f", "-i", "-c", script)
+	cmd.Dir = projectRoot
+	cmd.Env = append(os.Environ(),
+		"ZDOTDIR="+tmpDir,
+		"HOME="+tmpDir,
+		"XDG_CACHE_HOME="+tmpDir,
+		"XDG_CONFIG_HOME="+tmpDir,
+		"OPENAI_API_KEY=fake-key",
+		"SMART_SUGGESTION_AI_PROVIDER=openai",
+		"SMART_SUGGESTION_BINARY="+mockBinPath,
+		"SMART_SUGGESTION_AUTO_UPDATE=false",
+		"SMART_SUGGESTION_PROXY_MODE=true",
+		"TMUX=",
+		"KITTY_LISTEN_ON=",
+		"GHOSTTY_RESOURCES_DIR=",
+		"HERDR_ENV=1",
+		"HERDR_PANE_ID=",
+		"SMART_SUGGESTION_PROXY_ACTIVE=",
+	)
+
+	terminal, err := pty.Start(cmd)
+	if err != nil {
+		t.Fatalf("Failed to start zsh with a TTY: %v", err)
+	}
+	defer terminal.Close()
+
+	outputCh := make(chan string, 1)
+	go func() {
+		var output bytes.Buffer
+		buf := make([]byte, 1024)
+		for {
+			n, readErr := terminal.Read(buf)
+			if n > 0 {
+				output.Write(buf[:n])
+			}
+			if readErr != nil {
+				outputCh <- output.String()
+				return
+			}
+		}
+	}()
+
+	var output string
+	select {
+	case output = <-outputCh:
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatal("Timed out waiting for proxy to start")
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("Proxy process failed: %v. Output:\n%s", err, output)
+	}
+
+	if !strings.Contains(output, "PROXY_STARTED:proxy --scrollback-lines 100") {
+		t.Fatalf("Proxy did not start without HERDR_PANE_ID. Output:\n%s", output)
 	}
 }

--- a/internal/zsh/integration_test.go
+++ b/internal/zsh/integration_test.go
@@ -629,6 +629,7 @@ func TestProxyNotStartedWithoutTTY(t *testing.T) {
 		"TMUX=",
 		"KITTY_LISTEN_ON=",
 		"GHOSTTY_RESOURCES_DIR=",
+		"HERDR_ENV=",
 		"SMART_SUGGESTION_PROXY_ACTIVE=",
 	)
 
@@ -678,6 +679,7 @@ func TestProxyStartedWithTTY(t *testing.T) {
 		"TMUX=",
 		"KITTY_LISTEN_ON=",
 		"GHOSTTY_RESOURCES_DIR=",
+		"HERDR_ENV=",
 		"SMART_SUGGESTION_PROXY_ACTIVE=",
 	)
 
@@ -717,5 +719,85 @@ func TestProxyStartedWithTTY(t *testing.T) {
 
 	if !strings.Contains(output, "PROXY_STARTED:proxy --scrollback-lines 100") {
 		t.Fatalf("Proxy did not start with a TTY. Output:\n%s", output)
+	}
+}
+
+func TestProxyNotStartedInHerdr(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get wd: %v", err)
+	}
+	projectRoot, err := filepath.Abs(filepath.Join(cwd, "..", ".."))
+	if err != nil {
+		t.Fatalf("Failed to get project root: %v", err)
+	}
+	pluginPath := filepath.Join(projectRoot, "smart-suggestion.plugin.zsh")
+
+	tmpDir := t.TempDir()
+	mockBinPath := filepath.Join(tmpDir, "smart-suggestion-bin")
+	mockBinContent := "#!/bin/sh\necho \"PROXY_STARTED:$*\"\n"
+	if err := os.WriteFile(mockBinPath, []byte(mockBinContent), 0755); err != nil {
+		t.Fatalf("Failed to create mock binary: %v", err)
+	}
+
+	script := fmt.Sprintf("source %q\necho PLUGIN_SOURCED\n", pluginPath)
+	cmd := exec.CommandContext(t.Context(), "zsh", "-f", "-i", "-c", script)
+	cmd.Dir = projectRoot
+	cmd.Env = append(os.Environ(),
+		"ZDOTDIR="+tmpDir,
+		"HOME="+tmpDir,
+		"XDG_CACHE_HOME="+tmpDir,
+		"XDG_CONFIG_HOME="+tmpDir,
+		"OPENAI_API_KEY=fake-key",
+		"SMART_SUGGESTION_AI_PROVIDER=openai",
+		"SMART_SUGGESTION_BINARY="+mockBinPath,
+		"SMART_SUGGESTION_AUTO_UPDATE=false",
+		"SMART_SUGGESTION_PROXY_MODE=true",
+		"TMUX=",
+		"KITTY_LISTEN_ON=",
+		"GHOSTTY_RESOURCES_DIR=",
+		"HERDR_ENV=1",
+		"SMART_SUGGESTION_PROXY_ACTIVE=",
+	)
+
+	terminal, err := pty.Start(cmd)
+	if err != nil {
+		t.Fatalf("Failed to start zsh with a TTY: %v", err)
+	}
+	defer terminal.Close()
+
+	outputCh := make(chan string, 1)
+	go func() {
+		var output bytes.Buffer
+		buf := make([]byte, 1024)
+		for {
+			n, readErr := terminal.Read(buf)
+			if n > 0 {
+				output.Write(buf[:n])
+			}
+			if readErr != nil {
+				outputCh <- output.String()
+				return
+			}
+		}
+	}()
+
+	var output string
+	select {
+	case output = <-outputCh:
+	case <-time.After(5 * time.Second):
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		t.Fatal("Timed out waiting for plugin to source")
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("Plugin process failed: %v. Output:\n%s", err, output)
+	}
+
+	if !strings.Contains(output, "PLUGIN_SOURCED") {
+		t.Fatalf("Plugin did not return control in Herdr. Output:\n%s", output)
+	}
+	if strings.Contains(output, "PROXY_STARTED") {
+		t.Fatalf("Proxy started in Herdr session. Output:\n%s", output)
 	}
 }

--- a/smart-suggestion.plugin.zsh
+++ b/smart-suggestion.plugin.zsh
@@ -367,7 +367,7 @@ function smart-suggestion() {
 zle -N _do_smart_suggestion
 bindkey "$SMART_SUGGESTION_KEY" _do_smart_suggestion
 
-if [[ -z "$SMART_SUGGESTION_PROXY_ACTIVE" && "$SMART_SUGGESTION_PROXY_MODE" == "true" && -z "$TMUX" && -z "$KITTY_LISTEN_ON" && -z "$GHOSTTY_RESOURCES_DIR" ]]; then
+if [[ -z "$SMART_SUGGESTION_PROXY_ACTIVE" && "$SMART_SUGGESTION_PROXY_MODE" == "true" && -z "$TMUX" && -z "$KITTY_LISTEN_ON" && -z "$GHOSTTY_RESOURCES_DIR" && "$HERDR_ENV" != "1" ]]; then
     _run_smart_suggestion_proxy
 fi
 

--- a/smart-suggestion.plugin.zsh
+++ b/smart-suggestion.plugin.zsh
@@ -367,7 +367,7 @@ function smart-suggestion() {
 zle -N _do_smart_suggestion
 bindkey "$SMART_SUGGESTION_KEY" _do_smart_suggestion
 
-if [[ -z "$SMART_SUGGESTION_PROXY_ACTIVE" && "$SMART_SUGGESTION_PROXY_MODE" == "true" && -z "$TMUX" && -z "$KITTY_LISTEN_ON" && -z "$GHOSTTY_RESOURCES_DIR" && "$HERDR_ENV" != "1" ]]; then
+if [[ -z "$SMART_SUGGESTION_PROXY_ACTIVE" && "$SMART_SUGGESTION_PROXY_MODE" == "true" && -z "$TMUX" && -z "$KITTY_LISTEN_ON" && -z "$GHOSTTY_RESOURCES_DIR" && ( "$HERDR_ENV" != "1" || -z "$HERDR_PANE_ID" ) ]]; then
     _run_smart_suggestion_proxy
 fi
 


### PR DESCRIPTION
Capture pane output via herdr pane read when HERDR_ENV=1, skip proxy mode in Herdr sessions, and prefer Herdr over Kitty after Tmux.