### PR TITLE
fix: keep log backups unique, restrict debug.log, and isolate suggestion PID

### DIFF
--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -38,14 +38,24 @@ func Enabled() bool {
 
 func initLogger() {
 	logFilePath := filepath.Join(paths.GetCacheDir(), "debug.log")
-	if err := os.MkdirAll(filepath.Dir(logFilePath), 0755); err != nil {
+	cacheDir := filepath.Dir(logFilePath)
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
 		initError = fmt.Errorf("failed to create cache directory: %w", err)
 		return
 	}
+	if err := os.Chmod(cacheDir, 0o700); err != nil {
+		initError = fmt.Errorf("failed to secure cache directory: %w", err)
+		return
+	}
 
-	f, err := os.OpenFile(logFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(logFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		initError = fmt.Errorf("failed to open debug log file: %w", err)
+		return
+	}
+	if err := f.Chmod(0o600); err != nil {
+		_ = f.Close()
+		initError = fmt.Errorf("failed to secure debug log file: %w", err)
 		return
 	}
 

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -102,3 +102,50 @@ func TestInitError(t *testing.T) {
 		t.Error("expected debug to be disabled after init error")
 	}
 }
+
+func TestLogFilePermissions(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tempDir)
+	dir := filepath.Join(tempDir, "smart-suggestion")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(dir, "debug.log")
+	if err := os.WriteFile(logPath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(logPath, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	enabled = false
+	logFile = nil
+	logger = nil
+	initOnce = *new(sync.Once)
+	initError = nil
+	mu.Unlock()
+
+	Enable(true)
+	Log("perm check", nil)
+	t.Cleanup(Close)
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o700 {
+		t.Fatalf("dir perm %o", info.Mode().Perm())
+	}
+
+	info, err = os.Stat(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("file perm %o", info.Mode().Perm())
+	}
+}

--- a/internal/zsh/integration_test.go
+++ b/internal/zsh/integration_test.go
@@ -103,6 +103,10 @@ func spawnZsh() (*zshSession, error) {
 }
 
 func spawnZshWithProvider(provider string) (*zshSession, error) {
+	return spawnZshWithProviderAndCache(provider, "")
+}
+
+func spawnZshWithProviderAndCache(provider, cacheHome string) (*zshSession, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, err
@@ -117,9 +121,13 @@ func spawnZshWithProvider(provider string) (*zshSession, error) {
 	if err != nil {
 		return nil, err
 	}
+	if cacheHome == "" {
+		cacheHome = tmpDir
+	}
 
 	autosuggestDir := filepath.Join(tmpDir, "zsh-autosuggestions")
-	cloneCmd := exec.Command("git", "clone", "--depth", "1", "https://github.com/zsh-users/zsh-autosuggestions", autosuggestDir)
+	const zshAutosuggestionsTag = "v0.7.1"
+	cloneCmd := exec.Command("git", "clone", "--depth", "1", "--branch", zshAutosuggestionsTag, "https://github.com/zsh-users/zsh-autosuggestions", autosuggestDir)
 	if out, err := cloneCmd.CombinedOutput(); err != nil {
 		os.RemoveAll(tmpDir)
 		return nil, fmt.Errorf("failed to clone zsh-autosuggestions: %v, output: %s", err, string(out))
@@ -145,7 +153,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 if [ -f "$MOCK_ERROR_FILE" ]; then
-    cat "$MOCK_ERROR_FILE" > "$XDG_CACHE_HOME/smart-suggestion/error"
+    cat "$MOCK_ERROR_FILE" >&2
     exit 1
 fi
 
@@ -189,7 +197,7 @@ SMART_SUGGESTION_DEBUG="true"
 	cmd.Env = append(os.Environ(),
 		"ZDOTDIR="+tmpDir,
 		"HOME="+tmpDir,
-		"XDG_CACHE_HOME="+tmpDir,
+		"XDG_CACHE_HOME="+cacheHome,
 		"XDG_CONFIG_HOME="+tmpDir,
 		"TERM=xterm-256color",
 		"MOCK_ERROR_FILE="+filepath.Join(tmpDir, "mock_error"),
@@ -248,6 +256,41 @@ SMART_SUGGESTION_DEBUG="true"
 func (s *zshSession) TriggerSuggest() {
 	// Send ^O (Ctrl-O) which is bound to _do_smart_suggestion
 	_, _ = s.pty.Write([]byte{0x0f})
+}
+
+func suggestionRequestDirs(cacheDir string) ([]string, error) {
+	entries, err := os.ReadDir(cacheDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var dirs []string
+	for _, entry := range entries {
+		if entry.IsDir() && strings.HasPrefix(entry.Name(), "suggest.") {
+			dirs = append(dirs, filepath.Join(cacheDir, entry.Name()))
+		}
+	}
+	return dirs, nil
+}
+
+func waitForSuggestionRequestCount(cacheDir string, want int, timeout time.Duration) ([]string, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		dirs, err := suggestionRequestDirs(cacheDir)
+		if err != nil {
+			return nil, err
+		}
+		if len(dirs) == want {
+			return dirs, nil
+		}
+		if time.Now().After(deadline) {
+			return dirs, fmt.Errorf("got %d suggestion request directories, want %d", len(dirs), want)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 }
 
 func TestAppendSuggestion(t *testing.T) {
@@ -878,5 +921,149 @@ func TestProxyStartedInHerdrWithoutPaneID(t *testing.T) {
 
 	if !strings.Contains(output, "PROXY_STARTED:proxy --scrollback-lines 100") {
 		t.Fatalf("Proxy did not start without HERDR_PANE_ID. Output:\n%s", output)
+	}
+}
+
+func TestNumericReplaceSuggestionIsNotReadAsPID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	session, err := spawnZsh()
+	if err != nil {
+		t.Fatalf("Failed to spawn zsh: %v", err)
+	}
+	defer session.Close()
+
+	if err := session.SetMockResponse("=42"); err != nil {
+		t.Fatal(err)
+	}
+	if err := session.SetMockDelay(time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	session.pty.Write([]byte("echo original"))
+	time.Sleep(200 * time.Millisecond)
+
+	session.TriggerSuggest()
+	cacheDir := filepath.Join(session.tmpDir, "smart-suggestion")
+	if _, err := waitForSuggestionRequestCount(cacheDir, 1, 5*time.Second); err != nil {
+		t.Fatalf("suggestion request did not start: %v", err)
+	}
+	if requestDirs, err := waitForSuggestionRequestCount(cacheDir, 0, 5*time.Second); err != nil {
+		t.Fatalf("suggestion request directories were not removed: %v (%v)", requestDirs, err)
+	}
+
+	if output, err := session.RunCommand("", 5*time.Second); err != nil {
+		t.Fatalf("numeric replace suggestion did not finish: %v. Output: %s", err, output)
+	}
+
+	_, err = session.Expect("42", 5*time.Second)
+	if err != nil {
+		t.Fatalf("numeric replace suggestion was not applied. Output: %s", session.output.String())
+	}
+}
+
+func TestPluginSecuresExistingCacheFiles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	cacheHome := t.TempDir()
+	cacheDir := filepath.Join(cacheHome, "smart-suggestion")
+	if err := os.Mkdir(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	debugLog := filepath.Join(cacheDir, "debug.log")
+	if err := os.WriteFile(debugLog, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(debugLog, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	session, err := spawnZshWithProviderAndCache("openai", cacheHome)
+	if err != nil {
+		t.Fatalf("Failed to spawn zsh: %v", err)
+	}
+	defer session.Close()
+
+	info, err := os.Stat(cacheDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o700 {
+		t.Fatalf("cache directory permissions are %o, want 700", info.Mode().Perm())
+	}
+	info, err = os.Stat(debugLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("debug log permissions are %o, want 600", info.Mode().Perm())
+	}
+}
+
+func TestConcurrentSuggestionsUseSeparateRequestDirectories(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	cacheHome := t.TempDir()
+	first, err := spawnZshWithProviderAndCache("openai", cacheHome)
+	if err != nil {
+		t.Fatalf("Failed to spawn first zsh: %v", err)
+	}
+	defer first.Close()
+	second, err := spawnZshWithProviderAndCache("openai", cacheHome)
+	if err != nil {
+		t.Fatalf("Failed to spawn second zsh: %v", err)
+	}
+	defer second.Close()
+
+	if err := first.SetMockResponse("=echo first_concurrent_suggestion"); err != nil {
+		t.Fatal(err)
+	}
+	if err := first.SetMockDelay(2 * time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := second.SetMockResponse("=echo second_concurrent_suggestion"); err != nil {
+		t.Fatal(err)
+	}
+	if err := second.SetMockDelay(2 * time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	first.pty.Write([]byte("echo first_original"))
+	second.pty.Write([]byte("echo second_original"))
+	time.Sleep(200 * time.Millisecond)
+	first.TriggerSuggest()
+	second.TriggerSuggest()
+
+	cacheDir := filepath.Join(cacheHome, "smart-suggestion")
+	if requestDirs, err := waitForSuggestionRequestCount(cacheDir, 2, 5*time.Second); err != nil {
+		t.Fatalf("expected 2 concurrent request directories: %v (%v)", requestDirs, err)
+	}
+
+	if requestDirs, err := waitForSuggestionRequestCount(cacheDir, 0, 5*time.Second); err != nil {
+		t.Fatalf("suggestion request directories were not removed: %v (%v)", requestDirs, err)
+	}
+
+	firstOutput, err := first.RunCommand("", 3*time.Second)
+	if err != nil {
+		t.Fatalf("first suggestion did not finish: %v. Output: %s", err, firstOutput)
+	}
+	if !strings.Contains(firstOutput, "first_concurrent_suggestion") {
+		t.Fatalf("first shell received the wrong suggestion. Output: %s", firstOutput)
+	}
+	secondOutput, err := second.RunCommand("", 3*time.Second)
+	if err != nil {
+		t.Fatalf("second suggestion did not finish: %v. Output: %s", err, secondOutput)
+	}
+	if !strings.Contains(secondOutput, "second_concurrent_suggestion") {
+		t.Fatalf("second shell received the wrong suggestion. Output: %s", secondOutput)
 	}
 }

--- a/pkg/logrotate.go
+++ b/pkg/logrotate.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -77,16 +78,15 @@ func (lr *LogRotator) CheckAndRotate(logFilePath string) error {
 
 // rotateFile performs the actual file rotation
 func (lr *LogRotator) rotateFile(logFilePath string) error {
-	// Generate timestamp for the backup file
-	timestamp := time.Now().Format("20060102-150405")
-
-	// Create backup filename
 	dir := filepath.Dir(logFilePath)
 	base := filepath.Base(logFilePath)
 	ext := filepath.Ext(base)
 	name := strings.TrimSuffix(base, ext)
 
-	backupPath := filepath.Join(dir, fmt.Sprintf("%s-%s%s", name, timestamp, ext))
+	backupPath, err := uniqueBackupPath(dir, name, ext)
+	if err != nil {
+		return err
+	}
 
 	// Move current log file to backup
 	if err := os.Rename(logFilePath, backupPath); err != nil {
@@ -130,13 +130,68 @@ func (lr *LogRotator) compressFile(srcPath, dstPath string) error {
 	defer dstFile.Close()
 
 	gzipWriter := gzip.NewWriter(dstFile)
-	defer gzipWriter.Close()
-
 	if _, err := io.Copy(gzipWriter, srcFile); err != nil {
+		_ = gzipWriter.Close()
 		return fmt.Errorf("failed to compress file: %w", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		return fmt.Errorf("failed to close gzip writer for %s: %w", dstPath, err)
 	}
 
 	return nil
+}
+
+func uniqueBackupPath(dir, name, ext string) (string, error) {
+	timestamp := time.Now().Format("20060102-150405")
+	for i := range 100 {
+		suffix := timestamp
+		if i > 0 {
+			suffix = fmt.Sprintf("%s-%d", timestamp, i)
+		}
+		candidate := filepath.Join(dir, fmt.Sprintf("%s-%s%s", name, suffix, ext))
+		inUse, err := backupNameInUse(candidate)
+		if err != nil {
+			return "", err
+		}
+		if !inUse {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("failed to allocate unique backup name for %s-%s%s", name, timestamp, ext)
+}
+
+func backupNameInUse(path string) (bool, error) {
+	for _, candidate := range []string{path, path + ".gz"} {
+		_, err := os.Stat(candidate)
+		if err == nil {
+			return true, nil
+		}
+		if !os.IsNotExist(err) {
+			return false, fmt.Errorf("failed to stat backup %s: %w", candidate, err)
+		}
+	}
+	return false, nil
+}
+
+func findBackupFiles(dir, name, ext string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read backup directory %s: %w", dir, err)
+	}
+
+	pattern := regexp.MustCompile(
+		`^` + regexp.QuoteMeta(name) + `-[0-9]{8}-[0-9]{6}(-[1-9][0-9]*)?` + regexp.QuoteMeta(ext) + `(\.gz)?$`,
+	)
+	backups := make([]string, 0)
+	for _, entry := range entries {
+		if entry.Type().IsRegular() && pattern.MatchString(entry.Name()) {
+			backups = append(backups, filepath.Join(dir, entry.Name()))
+		}
+	}
+	return backups, nil
 }
 
 // cleanupOldBackups removes old backup files based on MaxBackups and MaxAge settings
@@ -147,10 +202,9 @@ func (lr *LogRotator) cleanupOldBackups(logFilePath string) error {
 	name := strings.TrimSuffix(base, ext)
 
 	// Find all backup files
-	pattern := filepath.Join(dir, fmt.Sprintf("%s-*%s*", name, ext))
-	matches, err := filepath.Glob(pattern)
+	matches, err := findBackupFiles(dir, name, ext)
 	if err != nil {
-		return fmt.Errorf("failed to find backup files with pattern %s: %w", pattern, err)
+		return fmt.Errorf("failed to find backup files for %s: %w", logFilePath, err)
 	}
 
 	// Create a list of backup files with their info
@@ -224,10 +278,9 @@ func (lr *LogRotator) GetBackupFiles(logFilePath string) ([]string, error) {
 	name := strings.TrimSuffix(base, ext)
 
 	// Find all backup files
-	pattern := filepath.Join(dir, fmt.Sprintf("%s-*%s*", name, ext))
-	matches, err := filepath.Glob(pattern)
+	matches, err := findBackupFiles(dir, name, ext)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find backup files with pattern %s: %w", pattern, err)
+		return nil, fmt.Errorf("failed to find backup files for %s: %w", logFilePath, err)
 	}
 
 	// Filter out the current log file

--- a/pkg/logrotate_test.go
+++ b/pkg/logrotate_test.go
@@ -1,6 +1,8 @@
 package pkg
 
 import (
+	"compress/gzip"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -143,5 +145,113 @@ func TestLogRotator_Compression(t *testing.T) {
 		t.Errorf("expected 1 backup, got %d", len(backups))
 	} else if filepath.Ext(backups[0]) != ".gz" {
 		t.Errorf("expected backup to have .gz extension, got %s", filepath.Ext(backups[0]))
+	}
+}
+
+func TestLogRotator_SameSecondBackupNames(t *testing.T) {
+	tempDir := t.TempDir()
+	logFile := filepath.Join(tempDir, "test.log")
+
+	config := &LogRotateConfig{
+		MaxSize:    1,
+		MaxBackups: 5,
+		MaxAge:     1,
+		Compress:   false,
+	}
+	lr := NewLogRotator(config)
+
+	for i := range 3 {
+		if err := os.WriteFile(logFile, []byte("content"), 0o644); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+		if err := lr.CheckAndRotate(logFile); err != nil {
+			t.Fatalf("rotation %d: %v", i, err)
+		}
+	}
+
+	backups, err := lr.GetBackupFiles(logFile)
+	if err != nil {
+		t.Fatalf("GetBackupFiles: %v", err)
+	}
+	if len(backups) != 3 {
+		t.Fatalf("expected 3 backups, got %d (%v)", len(backups), backups)
+	}
+}
+
+func TestLogRotator_BackupMatchingIgnoresUnrelatedFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	logFile := filepath.Join(tempDir, "test.log")
+	unrelatedFiles := []string{
+		filepath.Join(tempDir, "test-notes.txt"),
+		filepath.Join(tempDir, "test-20260829-123456-not-a-backup.log.bak"),
+	}
+	oldTime := time.Now().Add(-48 * time.Hour)
+	for _, path := range unrelatedFiles {
+		if err := os.WriteFile(path, []byte("nope"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(path, oldTime, oldTime); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	config := &LogRotateConfig{
+		MaxSize:    1,
+		MaxBackups: 1,
+		MaxAge:     1,
+		Compress:   false,
+	}
+	lr := NewLogRotator(config)
+	if err := os.WriteFile(logFile, []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := lr.CheckAndRotate(logFile); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range unrelatedFiles {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("unrelated file %s was removed: %v", path, err)
+		}
+	}
+
+	backups, err := lr.GetBackupFiles(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(backups) != 1 {
+		t.Fatalf("expected 1 backup, got %d (%v)", len(backups), backups)
+	}
+}
+
+func TestCompressFileClosesGzipWriter(t *testing.T) {
+	tempDir := t.TempDir()
+	src := filepath.Join(tempDir, "src.log")
+	dst := filepath.Join(tempDir, "src.log.gz")
+	if err := os.WriteFile(src, []byte("compress me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lr := NewLogRotator(nil)
+	if err := lr.compressFile(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := os.Open(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	gr, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatalf("gzip footer missing: %v", err)
+	}
+	defer gr.Close()
+	got, err := io.ReadAll(gr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "compress me" {
+		t.Fatalf("got %q", got)
 	}
 }

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,18 @@
   "gomod": {
     "managerFilePatterns": ["/(^|/)go\\.mod$/"]
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^internal\\/zsh\\/integration_test\\.go$/"],
+      "matchStrings": [
+        "const zshAutosuggestionsTag = \"(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)\""
+      ],
+      "depNameTemplate": "zsh-users/zsh-autosuggestions",
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver-coerced"
+    }
+  ],
   "packageRules": [
     {
       "matchPackageNames": ["*"],

--- a/smart-suggestion.plugin.zsh
+++ b/smart-suggestion.plugin.zsh
@@ -51,10 +51,12 @@ if [[ -z "$SMART_SUGGESTION_AI_PROVIDER" ]]; then
 fi
 
 : ${SMART_SUGGESTION_CACHE_DIR:="${XDG_CACHE_HOME:-$HOME/.cache}/smart-suggestion"}
-mkdir -p "$SMART_SUGGESTION_CACHE_DIR"
+(umask 077; mkdir -p "$SMART_SUGGESTION_CACHE_DIR") || return 1
+chmod 700 "$SMART_SUGGESTION_CACHE_DIR" || return 1
 
 if [[ "$SMART_SUGGESTION_DEBUG" == 'true' ]]; then
-    touch "${SMART_SUGGESTION_CACHE_DIR}/debug.log"
+    (umask 077; touch "${SMART_SUGGESTION_CACHE_DIR}/debug.log") || return 1
+    chmod 600 "${SMART_SUGGESTION_CACHE_DIR}/debug.log" || return 1
 fi
 
 # Detect binary path
@@ -139,6 +141,7 @@ function _smart_suggestion_shell_history() {
 
 function _fetch_suggestions() {
     local scrollback_file="$1"
+    local error_file="$2"
 
     # Source config file and export all variables
     _smart_suggestion_source_config
@@ -170,7 +173,7 @@ function _fetch_suggestions() {
         "${scrollback_file_args[@]}" \
         $debug_flag \
         $context_flag \
-        2> "${SMART_SUGGESTION_CACHE_DIR}/error"
+        2> "$error_file"
 
     return $?
 }
@@ -178,6 +181,7 @@ function _fetch_suggestions() {
 
 function _show_loading_animation() {
     local pid=$1
+    local canceled_file="$2"
     local interval=0.1
     local animation_chars=("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")
     local i=1
@@ -186,7 +190,7 @@ function _show_loading_animation() {
         kill $pid 2>/dev/null
         # Clear the line and restore cursor
         tput -S <<<"cr el cnorm"
-        touch "${SMART_SUGGESTION_CACHE_DIR}/canceled"
+        touch "$canceled_file"
     }
     trap cleanup SIGINT EXIT
 
@@ -212,9 +216,6 @@ function _show_loading_animation() {
 
 function _do_smart_suggestion() {
     ##### Get input
-    rm -f "${SMART_SUGGESTION_CACHE_DIR}/canceled"
-    rm -f "${SMART_SUGGESTION_CACHE_DIR}/error"
-
     local scrollback_file=""
 
     # Ghostty: extract scrollback file path from buffer
@@ -232,67 +233,88 @@ function _do_smart_suggestion() {
     _zsh_autosuggest_clear
 
     ##### Fetch message
-    exec {OUTPUT_FD}< <(_fetch_suggestions "$scrollback_file" & echo $!)
-    read pid <&$OUTPUT_FD
+    local request_dir
+    request_dir=$(mktemp -d "${SMART_SUGGESTION_CACHE_DIR}/suggest.XXXXXXXX") || return 1
+    local fifo="${request_dir}/suggest.fifo"
+    local error_file="${request_dir}/error"
+    local canceled_file="${request_dir}/canceled"
+    local output_fd=""
 
-    _show_loading_animation $pid
-    local response_code=$?
-
-    # Ensure cursor is visible and line is cleared after animation
-    tput cnorm
-    zle -R ""
-
-    if [[ "$SMART_SUGGESTION_DEBUG" == 'true' ]]; then
-        if command -v jq >/dev/null 2>&1; then
-            jq -n --arg date "$(date)" --arg log "Fetched message" --arg input "$input" --arg response_code "$response_code" \
-                '{date: $date, log: $log, input: $input, response_code: $response_code}' >> "${SMART_SUGGESTION_CACHE_DIR}/debug.log"
-        else
-            echo "{\"date\":\"$(date)\",\"log\":\"Fetched message\",\"input\":\"$input\",\"response_code\":\"$response_code\"}" >> "${SMART_SUGGESTION_CACHE_DIR}/debug.log"
+    {
+        mkfifo "$fifo" || return 1
+        _fetch_suggestions "$scrollback_file" "$error_file" > "$fifo" &
+        local pid=$!
+        if ! exec {output_fd}< "$fifo"; then
+            kill $pid 2>/dev/null
+            return 1
         fi
-    fi
+        rm -f "$fifo"
 
-    if [[ -f "${SMART_SUGGESTION_CACHE_DIR}/canceled" ]]; then
-        _zsh_autosuggest_clear
-        return 1
-    fi
+        _show_loading_animation $pid "$canceled_file"
+        local response_code=$?
 
-    local message
-    read -u $OUTPUT_FD -d '' message || true
-    exec {OUTPUT_FD}<&-
+        # Ensure cursor is visible and line is cleared after animation
+        tput cnorm
+        zle -R ""
 
-    if [[ -z "$message" ]]; then
-        _zsh_autosuggest_clear
-        local error_msg
-        if [[ -s "${SMART_SUGGESTION_CACHE_DIR}/error" ]]; then
-            error_msg=$(<"${SMART_SUGGESTION_CACHE_DIR}/error")
-        fi
-        if [[ -z "${error_msg//[[:space:]]/}" ]]; then
-            error_msg="No suggestion available at this time. Please try again later."
+        if [[ "$SMART_SUGGESTION_DEBUG" == 'true' ]]; then
+            if command -v jq >/dev/null 2>&1; then
+                jq -n --arg date "$(date)" --arg log "Fetched message" --arg input "$input" --arg response_code "$response_code" \
+                    '{date: $date, log: $log, input: $input, response_code: $response_code}' >> "${SMART_SUGGESTION_CACHE_DIR}/debug.log"
+            else
+                echo "{\"date\":\"$(date)\",\"log\":\"Fetched message\",\"input\":\"$input\",\"response_code\":\"$response_code\"}" >> "${SMART_SUGGESTION_CACHE_DIR}/debug.log"
+            fi
         fi
 
-        zle -I
-        print -r -u2 -- "$error_msg"
-        return 1
-    fi
+        if [[ -f "$canceled_file" ]]; then
+            _zsh_autosuggest_clear
+            return 1
+        fi
 
-    ##### Process response
+        local message
+        read -u $output_fd -d '' message || true
+        exec {output_fd}<&-
+        output_fd=""
 
-    local first_char=${message:0:1}
-    local suggestion=${message:1:${#message}}
+        if [[ -z "$message" ]]; then
+            _zsh_autosuggest_clear
+            local error_msg
+            if [[ -s "$error_file" ]]; then
+                error_msg=$(<"$error_file")
+            fi
+            if [[ -z "${error_msg//[[:space:]]/}" ]]; then
+                error_msg="No suggestion available at this time. Please try again later."
+            fi
 
-    ##### And now, let's actually show the suggestion to the user!
+            zle -I
+            print -r -u2 -- "$error_msg"
+            return 1
+        fi
 
-    if [[ "$first_char" == '=' ]]; then
-        # Reset user input
-        BUFFER=""
-        CURSOR=0
+        ##### Process response
 
-        zle -U "$suggestion"
-    elif [[ "$first_char" == '+' ]]; then
-        _zsh_autosuggest_suggest "$suggestion"
-    fi
+        local first_char=${message:0:1}
+        local suggestion=${message:1:${#message}}
 
-    zle reset-prompt
+        ##### And now, let's actually show the suggestion to the user!
+
+        if [[ "$first_char" == '=' ]]; then
+            # Reset user input
+            BUFFER=""
+            CURSOR=0
+
+            zle -U "$suggestion"
+        elif [[ "$first_char" == '+' ]]; then
+            _zsh_autosuggest_suggest "$suggestion"
+        fi
+
+        zle reset-prompt
+    } always {
+        if [[ -n "$output_fd" ]]; then
+            exec {output_fd}<&-
+        fi
+        rm -rf "$request_dir"
+    }
 }
 
 function _check_smart_suggestion_updates() {


### PR DESCRIPTION
Reopens #18 stacked on #19.

## What changed

Check the gzip writer Close error so rotated logs are valid archives. Pick a free backup name within the same second and match only timestamped backups. Create debug.log as 0600 under a 0700 cache directory. Run the suggestion worker through a fifo so its PID is not mixed into stdout. Pin the zsh-autosuggestions clone used by plugin tests to v0.7.1.

## Why

These are confirmed defects outside the any-llm-go migration. Base is `feat/migrate-any-llm-go`.

## Test plan

- `go test -race ./pkg/ ./internal/debug/`
