### PR TITLE
fix: keep log backups unique, restrict debug.log, and isolate suggestion PID

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,7 @@ Key variables:
 - `SMART_SUGGESTION_KEY`: Trigger key (default `^o`).
 - `SMART_SUGGESTION_PROXY_MODE`: `true`/`false`. Enables the PTY wrapper for better context.
 - `SMART_SUGGESTION_DEBUG`: Enable debug logging to `~/.cache/smart-suggestion/debug.log`.
+- `SMART_SUGGESTION_CACHE_DIR`: Cache directory used by both the plugin and the Go binary (default `~/.cache/smart-suggestion`).
 
 # Development Conventions
 

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Alternatively, you can configure the plugin using global environment variables i
 | `SMART_SUGGESTION_AUTO_UPDATE`       | Enable automatic update checking      | `true`                                  | `true`, `false`                                         |
 | `SMART_SUGGESTION_UPDATE_INTERVAL`   | Days between update checks            | `7`                                     | Any positive integer                                    |
 | `SMART_SUGGESTION_BINARY`            | Path to the `smart-suggestion` binary | Auto-detected                           | Any valid filepath to a valid `smart-suggestion` binary |
+| `SMART_SUGGESTION_CACHE_DIR`         | Cache directory for logs and state    | `~/.cache/smart-suggestion`             | Any valid directory path                                |
 
 If `SMART_SUGGESTION_BINARY` is not specified, we look for one in the following locations:
 

--- a/cmd/smart-suggestion/main.go
+++ b/cmd/smart-suggestion/main.go
@@ -305,8 +305,13 @@ func buildRootCmd() *cobra.Command {
 
 	var rotateCmd = &cobra.Command{
 		Use:   "rotate-logs",
-		Short: "Rotate log files to prevent them from growing too large",
-		RunE:  runRotateLogs,
+		Short: "Rotate a log file (safe while the proxy is writing it)",
+		Long: `Rotate a log file.
+
+The rotator and the proxy writer share an exclusive per-log lock. A live
+proxy reopens its log fd after the file is renamed, so rotate-logs can be
+used on a session log that is still being written.`,
+		RunE: runRotateLogs,
 	}
 	rotateCmd.Flags().StringVarP(&proxyLogFile, "log-file", "l", "", "Log file path to rotate (required)")
 	rotateCmd.Flags().BoolVarP(&dbg, "debug", "d", false, "Enable debug logging")

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -38,14 +38,24 @@ func Enabled() bool {
 
 func initLogger() {
 	logFilePath := filepath.Join(paths.GetCacheDir(), "debug.log")
-	if err := os.MkdirAll(filepath.Dir(logFilePath), 0755); err != nil {
+	cacheDir := filepath.Dir(logFilePath)
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
 		initError = fmt.Errorf("failed to create cache directory: %w", err)
 		return
 	}
+	if err := os.Chmod(cacheDir, 0o700); err != nil {
+		initError = fmt.Errorf("failed to secure cache directory: %w", err)
+		return
+	}
 
-	f, err := os.OpenFile(logFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(logFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		initError = fmt.Errorf("failed to open debug log file: %w", err)
+		return
+	}
+	if err := f.Chmod(0o600); err != nil {
+		_ = f.Close()
+		initError = fmt.Errorf("failed to secure debug log file: %w", err)
 		return
 	}
 

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -102,3 +102,50 @@ func TestInitError(t *testing.T) {
 		t.Error("expected debug to be disabled after init error")
 	}
 }
+
+func TestLogFilePermissions(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", tempDir)
+	dir := filepath.Join(tempDir, "smart-suggestion")
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(dir, "debug.log")
+	if err := os.WriteFile(logPath, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(logPath, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mu.Lock()
+	enabled = false
+	logFile = nil
+	logger = nil
+	initOnce = *new(sync.Once)
+	initError = nil
+	mu.Unlock()
+
+	Enable(true)
+	Log("perm check", nil)
+	t.Cleanup(Close)
+
+	info, err := os.Stat(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o700 {
+		t.Fatalf("dir perm %o", info.Mode().Perm())
+	}
+
+	info, err = os.Stat(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("file perm %o", info.Mode().Perm())
+	}
+}

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -8,19 +8,25 @@ import (
 	"testing"
 )
 
+func resetLoggerForTest(t *testing.T) {
+	t.Helper()
+	Close()
+	mu.Lock()
+	enabled = false
+	logFile = nil
+	logger = nil
+	initOnce = sync.Once{}
+	initError = nil
+	mu.Unlock()
+	t.Cleanup(Close)
+}
+
 func TestLog(t *testing.T) {
 	// Create a temp dir for cache
 	tempDir := t.TempDir()
 	t.Setenv("XDG_CACHE_HOME", tempDir)
 
-	// Reset state
-	mu.Lock()
-	enabled = false
-	logFile = nil
-	logger = nil
-	initOnce = *new(sync.Once) // Reset sync.Once
-	initError = nil
-	mu.Unlock()
+	resetLoggerForTest(t)
 
 	// Enable logging
 	Enable(true)
@@ -52,12 +58,11 @@ func TestLog(t *testing.T) {
 	if entry["key"] != "value" {
 		t.Errorf("expected data key 'value', got %v", entry["key"])
 	}
-
-	// Clean up
-	Close()
 }
 
 func TestClose(t *testing.T) {
+	t.Setenv("XDG_CACHE_HOME", t.TempDir())
+	resetLoggerForTest(t)
 	Enable(true)
 	Log("message", nil)
 	Close()
@@ -70,6 +75,7 @@ func TestClose(t *testing.T) {
 }
 
 func TestEnableFalse(t *testing.T) {
+	resetLoggerForTest(t)
 	Enable(false)
 	if Enabled() {
 		t.Error("expected debug to be disabled")
@@ -85,14 +91,7 @@ func TestInitError(t *testing.T) {
 	cacheDir := filepath.Join(tempDir, "smart-suggestion")
 	os.WriteFile(cacheDir, []byte("not a directory"), 0644)
 
-	// Reset state
-	mu.Lock()
-	enabled = false
-	logFile = nil
-	logger = nil
-	initOnce = *new(sync.Once)
-	initError = nil
-	mu.Unlock()
+	resetLoggerForTest(t)
 
 	Enable(true)
 	Log("test", nil)
@@ -103,49 +102,40 @@ func TestInitError(t *testing.T) {
 	}
 }
 
-func TestLogFilePermissions(t *testing.T) {
+func TestExistingCacheIsMadePrivate(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv("XDG_CACHE_HOME", tempDir)
+
 	dir := filepath.Join(tempDir, "smart-suggestion")
-	if err := os.Mkdir(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chmod(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
 	logPath := filepath.Join(dir, "debug.log")
-	if err := os.WriteFile(logPath, nil, 0o644); err != nil {
+	if err := os.Mkdir(dir, 0o777); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chmod(logPath, 0o644); err != nil {
+	// Force group/other access in case the process umask already masked it.
+	if err := os.Chmod(dir, 0o777); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(logPath, []byte("old"), 0o666); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(logPath, 0o666); err != nil {
 		t.Fatal(err)
 	}
 
-	mu.Lock()
-	enabled = false
-	logFile = nil
-	logger = nil
-	initOnce = *new(sync.Once)
-	initError = nil
-	mu.Unlock()
-
+	resetLoggerForTest(t)
 	Enable(true)
 	Log("perm check", nil)
-	t.Cleanup(Close)
 
-	info, err := os.Stat(dir)
-	if err != nil {
-		t.Fatal(err)
+	assertOwnerPrivate := func(path string) {
+		t.Helper()
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if perm := info.Mode().Perm(); perm&0o077 != 0 {
+			t.Fatalf("%s is still accessible by group/other: %o", path, perm)
+		}
 	}
-	if info.Mode().Perm() != 0o700 {
-		t.Fatalf("dir perm %o", info.Mode().Perm())
-	}
-
-	info, err = os.Stat(logPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if info.Mode().Perm() != 0o600 {
-		t.Fatalf("file perm %o", info.Mode().Perm())
-	}
+	assertOwnerPrivate(dir)
+	assertOwnerPrivate(logPath)
 }

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -24,6 +24,7 @@ func resetLoggerForTest(t *testing.T) {
 func TestLog(t *testing.T) {
 	// Create a temp dir for cache
 	tempDir := t.TempDir()
+	t.Setenv("SMART_SUGGESTION_CACHE_DIR", "")
 	t.Setenv("XDG_CACHE_HOME", tempDir)
 
 	resetLoggerForTest(t)
@@ -61,6 +62,7 @@ func TestLog(t *testing.T) {
 }
 
 func TestClose(t *testing.T) {
+	t.Setenv("SMART_SUGGESTION_CACHE_DIR", "")
 	t.Setenv("XDG_CACHE_HOME", t.TempDir())
 	resetLoggerForTest(t)
 	Enable(true)
@@ -85,6 +87,7 @@ func TestEnableFalse(t *testing.T) {
 
 func TestInitError(t *testing.T) {
 	tempDir := t.TempDir()
+	t.Setenv("SMART_SUGGESTION_CACHE_DIR", "")
 	t.Setenv("XDG_CACHE_HOME", tempDir)
 
 	// Create a file where the directory should be
@@ -104,6 +107,7 @@ func TestInitError(t *testing.T) {
 
 func TestExistingCacheIsMadePrivate(t *testing.T) {
 	tempDir := t.TempDir()
+	t.Setenv("SMART_SUGGESTION_CACHE_DIR", "")
 	t.Setenv("XDG_CACHE_HOME", tempDir)
 
 	dir := filepath.Join(tempDir, "smart-suggestion")

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -8,6 +8,9 @@ import (
 const ProxyLogFilename = "proxy.log"
 
 func GetCacheDir() string {
+	if dir := os.Getenv("SMART_SUGGESTION_CACHE_DIR"); dir != "" {
+		return dir
+	}
 	cacheDir := os.Getenv("XDG_CACHE_HOME")
 	if cacheDir == "" {
 		homeDir, err := os.UserHomeDir()

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -6,8 +6,19 @@ import (
 )
 
 func TestGetCacheDir(t *testing.T) {
+	t.Run("SMART_SUGGESTION_CACHE_DIR set", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Setenv("SMART_SUGGESTION_CACHE_DIR", tempDir)
+		t.Setenv("XDG_CACHE_HOME", filepath.Join(t.TempDir(), "xdg"))
+
+		if got := GetCacheDir(); got != tempDir {
+			t.Errorf("expected %q, got %q", tempDir, got)
+		}
+	})
+
 	t.Run("XDG_CACHE_HOME set", func(t *testing.T) {
 		tempDir := t.TempDir()
+		t.Setenv("SMART_SUGGESTION_CACHE_DIR", "")
 		t.Setenv("XDG_CACHE_HOME", tempDir)
 
 		expected := filepath.Join(tempDir, "smart-suggestion")
@@ -17,6 +28,7 @@ func TestGetCacheDir(t *testing.T) {
 	})
 
 	t.Run("XDG_CACHE_HOME unset", func(t *testing.T) {
+		t.Setenv("SMART_SUGGESTION_CACHE_DIR", "")
 		t.Setenv("XDG_CACHE_HOME", "")
 		// We can't easily mock UserHomeDir without refactoring, so we'll check if it ends with .cache/smart-suggestion
 		// or if it falls back to TempDir
@@ -29,11 +41,25 @@ func TestGetCacheDir(t *testing.T) {
 }
 
 func TestGetDefaultProxyLogFile(t *testing.T) {
-	tempDir := t.TempDir()
-	t.Setenv("XDG_CACHE_HOME", tempDir)
+	t.Run("XDG_CACHE_HOME set", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Setenv("SMART_SUGGESTION_CACHE_DIR", "")
+		t.Setenv("XDG_CACHE_HOME", tempDir)
 
-	expected := filepath.Join(tempDir, "smart-suggestion", ProxyLogFilename)
-	if got := GetDefaultProxyLogFile(); got != expected {
-		t.Errorf("expected %q, got %q", expected, got)
-	}
+		expected := filepath.Join(tempDir, "smart-suggestion", ProxyLogFilename)
+		if got := GetDefaultProxyLogFile(); got != expected {
+			t.Errorf("expected %q, got %q", expected, got)
+		}
+	})
+
+	t.Run("SMART_SUGGESTION_CACHE_DIR set", func(t *testing.T) {
+		tempDir := t.TempDir()
+		t.Setenv("SMART_SUGGESTION_CACHE_DIR", tempDir)
+		t.Setenv("XDG_CACHE_HOME", filepath.Join(t.TempDir(), "xdg"))
+
+		expected := filepath.Join(tempDir, ProxyLogFilename)
+		if got := GetDefaultProxyLogFile(); got != expected {
+			t.Errorf("expected %q, got %q", expected, got)
+		}
+	})
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -401,7 +401,69 @@ func cleanupOldSessionLogs(baseLogPath string, maxAge time.Duration) error {
 		})
 	}
 
+	cleanupIdleLocks(dir, baseLogPath)
 	return nil
+}
+
+func cleanupIdleLocks(dir, baseLogPath string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		fullPath := filepath.Join(dir, name)
+		switch {
+		case strings.HasSuffix(name, ".rotate.lock"):
+			logPath := strings.TrimSuffix(fullPath, ".rotate.lock")
+			if exists, err := fileExists(logPath); err != nil || exists {
+				continue
+			}
+		case strings.HasSuffix(name, ".lock"):
+			logPath := sessionLogForLock(baseLogPath, fullPath)
+			if exists, err := fileExists(logPath); err != nil || exists {
+				continue
+			}
+		default:
+			continue
+		}
+		_ = pkg.RemoveIdleLock(fullPath)
+	}
+}
+
+func sessionLogForLock(baseLogPath, lockPath string) string {
+	baseLock := strings.TrimSuffix(baseLogPath, filepath.Ext(baseLogPath)) + ".lock"
+	if filepath.Clean(lockPath) == filepath.Clean(baseLock) {
+		return baseLogPath
+	}
+	sessionID := sessionIDFromLock(baseLock, lockPath)
+	return session.GetSessionBasedLogFile(baseLogPath, sessionID)
+}
+
+func sessionIDFromLock(baseLockPath, lockPath string) string {
+	base := filepath.Base(baseLockPath)
+	ext := filepath.Ext(base)
+	name := strings.TrimSuffix(base, ext)
+	lockBase := filepath.Base(lockPath)
+	prefix := name + "."
+	if !strings.HasPrefix(lockBase, prefix) || !strings.HasSuffix(lockBase, ext) {
+		return ""
+	}
+	return lockBase[len(prefix) : len(lockBase)-len(ext)]
+}
+
+func fileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
 }
 
 type lineLimitedWriter struct {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -401,69 +401,7 @@ func cleanupOldSessionLogs(baseLogPath string, maxAge time.Duration) error {
 		})
 	}
 
-	cleanupIdleLocks(dir, baseLogPath)
 	return nil
-}
-
-func cleanupIdleLocks(dir, baseLogPath string) {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return
-	}
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		name := entry.Name()
-		fullPath := filepath.Join(dir, name)
-		switch {
-		case strings.HasSuffix(name, ".rotate.lock"):
-			logPath := strings.TrimSuffix(fullPath, ".rotate.lock")
-			if exists, err := fileExists(logPath); err != nil || exists {
-				continue
-			}
-		case strings.HasSuffix(name, ".lock"):
-			logPath := sessionLogForLock(baseLogPath, fullPath)
-			if exists, err := fileExists(logPath); err != nil || exists {
-				continue
-			}
-		default:
-			continue
-		}
-		_ = pkg.RemoveIdleLock(fullPath)
-	}
-}
-
-func sessionLogForLock(baseLogPath, lockPath string) string {
-	baseLock := strings.TrimSuffix(baseLogPath, filepath.Ext(baseLogPath)) + ".lock"
-	if filepath.Clean(lockPath) == filepath.Clean(baseLock) {
-		return baseLogPath
-	}
-	sessionID := sessionIDFromLock(baseLock, lockPath)
-	return session.GetSessionBasedLogFile(baseLogPath, sessionID)
-}
-
-func sessionIDFromLock(baseLockPath, lockPath string) string {
-	base := filepath.Base(baseLockPath)
-	ext := filepath.Ext(base)
-	name := strings.TrimSuffix(base, ext)
-	lockBase := filepath.Base(lockPath)
-	prefix := name + "."
-	if !strings.HasPrefix(lockBase, prefix) || !strings.HasSuffix(lockBase, ext) {
-		return ""
-	}
-	return lockBase[len(prefix) : len(lockBase)-len(ext)]
-}
-
-func fileExists(path string) (bool, error) {
-	_, err := os.Stat(path)
-	if err == nil {
-		return true, nil
-	}
-	if os.IsNotExist(err) {
-		return false, nil
-	}
-	return false, err
 }
 
 type lineLimitedWriter struct {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -19,6 +19,7 @@ import (
 	"github.com/creack/pty"
 	"github.com/xyenon/smart-suggestion/internal/debug"
 	"github.com/xyenon/smart-suggestion/internal/session"
+	"github.com/xyenon/smart-suggestion/pkg"
 	"golang.org/x/term"
 )
 
@@ -419,6 +420,13 @@ func (w *lineLimitedWriter) Write(p []byte) (n int, err error) {
 }
 
 func (w *lineLimitedWriter) flush() error {
+	return pkg.WithLogRotateLock(w.filePath, w.flushLocked)
+}
+
+func (w *lineLimitedWriter) flushLocked() error {
+	if err := w.reopenIfRotated(); err != nil {
+		return err
+	}
 	if err := w.file.Truncate(0); err != nil {
 		return err
 	}
@@ -436,4 +444,32 @@ func (w *lineLimitedWriter) flush() error {
 		}
 	}
 	return nil
+}
+
+func (w *lineLimitedWriter) reopenIfRotated() error {
+	info, err := os.Stat(w.filePath)
+	switch {
+	case err == nil && sameFile(w.file, info):
+		return nil
+	case err != nil && !os.IsNotExist(err):
+		return err
+	}
+
+	if w.file != nil {
+		_ = w.file.Close()
+	}
+	f, err := os.OpenFile(w.filePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to reopen session log file after rotation: %w", err)
+	}
+	w.file = f
+	return nil
+}
+
+func sameFile(f *os.File, info os.FileInfo) bool {
+	current, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return os.SameFile(current, info)
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -173,13 +173,13 @@ func RunProxyWithIO(shell string, opts ProxyOptions, stdin io.Reader, stdout io.
 	if err != nil {
 		return fmt.Errorf("failed to open session log file: %w", err)
 	}
-	defer logFile.Close()
 
 	scrollbackLines := opts.ScrollbackLines
 	if scrollbackLines <= 0 {
 		scrollbackLines = 100
 	}
 	limitedLogWriter := newLineLimitedWriter(logFile, sessionLogFile, scrollbackLines)
+	defer limitedLogWriter.Close()
 
 	teeWriter := io.MultiWriter(stdout, limitedLogWriter)
 
@@ -317,6 +317,18 @@ func cleanupProcessLock(file *os.File, lockPath string) {
 	os.Remove(lockPath)
 }
 
+func sessionLockPathForLog(logPath string) string {
+	return strings.TrimSuffix(logPath, filepath.Ext(logPath)) + ".lock"
+}
+
+func staleIdleSessionLog(path string, cutoff time.Time) bool {
+	if isProcessRunning(sessionLockPathForLog(path)) {
+		return false
+	}
+	info, err := os.Stat(path)
+	return err == nil && info.ModTime().Before(cutoff)
+}
+
 func cleanupOldSessionLogs(baseLogPath string, maxAge time.Duration) error {
 	dir := filepath.Dir(baseLogPath)
 	base := filepath.Base(baseLogPath)
@@ -355,9 +367,15 @@ func cleanupOldSessionLogs(baseLogPath string, maxAge time.Duration) error {
 			continue
 		}
 
-		if info.ModTime().Before(cutoff) {
-			os.Remove(fullPath)
+		if !info.ModTime().Before(cutoff) || isProcessRunning(sessionLockPathForLog(fullPath)) {
+			continue
 		}
+		_ = pkg.WithLogRotateLock(fullPath, func() error {
+			if staleIdleSessionLog(fullPath, cutoff) {
+				os.Remove(fullPath)
+			}
+			return nil
+		})
 	}
 
 	return nil
@@ -417,6 +435,17 @@ func (w *lineLimitedWriter) Write(p []byte) (n int, err error) {
 	}
 
 	return len(p), nil
+}
+
+func (w *lineLimitedWriter) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.file == nil {
+		return nil
+	}
+	err := w.file.Close()
+	w.file = nil
+	return err
 }
 
 func (w *lineLimitedWriter) flush() error {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -250,38 +250,35 @@ func createProcessLock(lockPath string) (*os.File, error) {
 		return nil, fmt.Errorf("failed to create lock directory: %w", err)
 	}
 
-	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0644)
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
-		if os.IsExist(err) {
-			if isProcessRunning(lockPath) {
-				return nil, fmt.Errorf("another instance is already running")
-			}
-			os.Remove(lockPath)
-			file, err = os.OpenFile(lockPath, os.O_CREATE|os.O_WRONLY|os.O_EXCL, 0644)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create lock file: %w", err)
-			}
-		} else {
-			return nil, fmt.Errorf("failed to create lock file: %w", err)
-		}
+		return nil, fmt.Errorf("failed to create lock file: %w", err)
 	}
 
 	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
 		file.Close()
-		os.Remove(lockPath)
-		return nil, fmt.Errorf("failed to acquire lock: %w", err)
+		return nil, fmt.Errorf("another instance is already running")
 	}
 
-	pid := os.Getpid()
-	if _, err := file.WriteString(fmt.Sprintf("%d\n", pid)); err != nil {
+	if err := file.Truncate(0); err != nil {
+		syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
 		file.Close()
-		os.Remove(lockPath)
+		return nil, fmt.Errorf("failed to truncate lock file: %w", err)
+	}
+	if _, err := file.Seek(0, 0); err != nil {
+		syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		file.Close()
+		return nil, fmt.Errorf("failed to rewind lock file: %w", err)
+	}
+
+	if _, err := file.WriteString(fmt.Sprintf("%d\n", os.Getpid())); err != nil {
+		syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		file.Close()
 		return nil, fmt.Errorf("failed to write PID to lock file: %w", err)
 	}
-
 	if err := file.Sync(); err != nil {
+		syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
 		file.Close()
-		os.Remove(lockPath)
 		return nil, fmt.Errorf("failed to sync lock file: %w", err)
 	}
 
@@ -314,15 +311,41 @@ func cleanupProcessLock(file *os.File, lockPath string) {
 		syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
 		file.Close()
 	}
-	os.Remove(lockPath)
 }
 
-func sessionLockPathForLog(logPath string) string {
-	return strings.TrimSuffix(logPath, filepath.Ext(logPath)) + ".lock"
+func sessionLockPathForLog(baseLogPath, sessionLogPath string) string {
+	sessionID := sessionIDFromLog(baseLogPath, sessionLogPath)
+	baseLock := strings.TrimSuffix(baseLogPath, filepath.Ext(baseLogPath)) + ".lock"
+	return getSessionBasedLockFile(baseLock, sessionID)
 }
 
-func staleIdleSessionLog(path string, cutoff time.Time) bool {
-	if isProcessRunning(sessionLockPathForLog(path)) {
+func sessionIDFromLog(baseLogPath, sessionLogPath string) string {
+	base := filepath.Base(baseLogPath)
+	ext := filepath.Ext(base)
+	name := strings.TrimSuffix(base, ext)
+	sessionBase := filepath.Base(sessionLogPath)
+	prefix := name + "."
+	if !strings.HasPrefix(sessionBase, prefix) || !strings.HasSuffix(sessionBase, ext) {
+		return ""
+	}
+	return sessionBase[len(prefix) : len(sessionBase)-len(ext)]
+}
+
+func sessionLockHeld(lockPath string) bool {
+	file, err := os.OpenFile(lockPath, os.O_RDWR, 0)
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		return true
+	}
+	_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+	return false
+}
+
+func staleIdleSessionLog(baseLogPath, path string, cutoff time.Time) bool {
+	if sessionLockHeld(sessionLockPathForLog(baseLogPath, path)) {
 		return false
 	}
 	info, err := os.Stat(path)
@@ -357,7 +380,7 @@ func cleanupOldSessionLogs(baseLogPath string, maxAge time.Duration) error {
 			continue
 		}
 
-		if filename == filepath.Base(baseLogPath) {
+		if filename == filepath.Base(baseLogPath) || strings.HasSuffix(filename, ".lock") {
 			continue
 		}
 
@@ -367,11 +390,11 @@ func cleanupOldSessionLogs(baseLogPath string, maxAge time.Duration) error {
 			continue
 		}
 
-		if !info.ModTime().Before(cutoff) || isProcessRunning(sessionLockPathForLog(fullPath)) {
+		if !info.ModTime().Before(cutoff) || sessionLockHeld(sessionLockPathForLog(baseLogPath, fullPath)) {
 			continue
 		}
 		_ = pkg.WithLogRotateLock(fullPath, func() error {
-			if staleIdleSessionLog(fullPath, cutoff) {
+			if staleIdleSessionLog(baseLogPath, fullPath, cutoff) {
 				os.Remove(fullPath)
 			}
 			return nil

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -261,24 +261,20 @@ func createProcessLock(lockPath string) (*os.File, error) {
 	}
 
 	if err := file.Truncate(0); err != nil {
-		syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
-		file.Close()
+		cleanupProcessLock(file, lockPath)
 		return nil, fmt.Errorf("failed to truncate lock file: %w", err)
 	}
 	if _, err := file.Seek(0, 0); err != nil {
-		syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
-		file.Close()
+		cleanupProcessLock(file, lockPath)
 		return nil, fmt.Errorf("failed to rewind lock file: %w", err)
 	}
 
 	if _, err := file.WriteString(fmt.Sprintf("%d\n", os.Getpid())); err != nil {
-		syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
-		file.Close()
+		cleanupProcessLock(file, lockPath)
 		return nil, fmt.Errorf("failed to write PID to lock file: %w", err)
 	}
 	if err := file.Sync(); err != nil {
-		syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
-		file.Close()
+		cleanupProcessLock(file, lockPath)
 		return nil, fmt.Errorf("failed to sync lock file: %w", err)
 	}
 
@@ -501,9 +497,12 @@ func (w *lineLimitedWriter) flushLocked() error {
 func (w *lineLimitedWriter) reopenIfRotated() error {
 	info, err := os.Stat(w.filePath)
 	switch {
-	case err == nil && sameFile(w.file, info):
-		return nil
-	case err != nil && !os.IsNotExist(err):
+	case err == nil:
+		current, statErr := w.file.Stat()
+		if statErr == nil && os.SameFile(current, info) {
+			return nil
+		}
+	case !os.IsNotExist(err):
 		return err
 	}
 
@@ -516,12 +515,4 @@ func (w *lineLimitedWriter) reopenIfRotated() error {
 	}
 	w.file = f
 	return nil
-}
-
-func sameFile(f *os.File, info os.FileInfo) bool {
-	current, err := f.Stat()
-	if err != nil {
-		return false
-	}
-	return os.SameFile(current, info)
 }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -52,8 +52,8 @@ func TestCleanupProcessLock(t *testing.T) {
 	f, _ := os.Create(lockPath)
 	cleanupProcessLock(f, lockPath)
 
-	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
-		t.Error("expected lock file to be deleted")
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Error("expected lock file to remain after unlock")
 	}
 }
 
@@ -90,6 +90,43 @@ func TestCreateProcessLock_InvalidDir(t *testing.T) {
 	_, err := createProcessLock(lockPath)
 	if err == nil {
 		t.Error("expected error for invalid directory, got nil")
+	}
+}
+
+func TestSessionLockPathForLogExtensionless(t *testing.T) {
+	base := filepath.Join("tmp", "proxy")
+	sessionLog := session.GetSessionBasedLogFile(base, "pts_1")
+	got := sessionLockPathForLog(base, sessionLog)
+	want := filepath.Join("tmp", "proxy.pts_1.lock")
+	if got != want {
+		t.Fatalf("got %q, want %q (session log %q)", got, want, sessionLog)
+	}
+}
+
+func TestCleanupOldSessionLogsSkipsLiveExtensionlessSession(t *testing.T) {
+	tempDir := t.TempDir()
+	baseLog := filepath.Join(tempDir, "proxy")
+	sessionLog := session.GetSessionBasedLogFile(baseLog, "pts_1")
+	if err := os.WriteFile(sessionLog, []byte("keep"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(sessionLog, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	lockPath := sessionLockPathForLog(baseLog, sessionLog)
+	held, err := createProcessLock(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanupProcessLock(held, lockPath)
+
+	if err := cleanupOldSessionLogs(baseLog, 24*time.Hour); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(sessionLog); err != nil {
+		t.Fatalf("live extensionless session log was removed: %v", err)
 	}
 }
 
@@ -159,15 +196,12 @@ func TestProcessLock(t *testing.T) {
 		t.Error("expected error when creating duplicate lock, got nil")
 	}
 
-	// Cleanup
 	cleanupProcessLock(f, lockPath)
 
-	// Verify cleanup
-	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
-		t.Errorf("expected lock file to be deleted, but it exists")
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("expected lock file to remain after unlock: %v", err)
 	}
 
-	// Create again (should succeed)
 	f, err = createProcessLock(lockPath)
 	if err != nil {
 		t.Fatalf("failed to recreate lock: %v", err)
@@ -179,10 +213,13 @@ func TestCreateProcessLock_AlreadyRunning(t *testing.T) {
 	tempDir := t.TempDir()
 	lockPath := filepath.Join(tempDir, "running.lock")
 
-	// Create a lock file with current process PID
-	os.WriteFile(lockPath, []byte(strconv.Itoa(os.Getpid())), 0644)
+	held, err := createProcessLock(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanupProcessLock(held, lockPath)
 
-	_, err := createProcessLock(lockPath)
+	_, err = createProcessLock(lockPath)
 	if err == nil || !strings.Contains(err.Error(), "another instance is already running") {
 		t.Errorf("expected already running error, got %v", err)
 	}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -387,6 +387,35 @@ func TestLineLimitedWriterReopensAfterRotation(t *testing.T) {
 	}
 }
 
+func TestLineLimitedWriterCloseClosesReopenedFile(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "test.log")
+
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatalf("failed to create log file: %v", err)
+	}
+
+	w := newLineLimitedWriter(f, logPath, 10)
+	if _, err := w.Write([]byte("before\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	lr := pkg.NewLogRotator(&pkg.LogRotateConfig{MaxAge: 1, MaxBackups: 5, Compress: false})
+	if err := lr.ForceRotate(logPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write([]byte("after\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if w.file != nil {
+		t.Fatal("expected writer to release the log fd")
+	}
+}
+
 func TestLineLimitedWriter_Basic(t *testing.T) {
 	tempDir := t.TempDir()
 	logPath := filepath.Join(tempDir, "test.log")

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -103,6 +103,56 @@ func TestSessionLockPathForLogExtensionless(t *testing.T) {
 	}
 }
 
+func TestCleanupIdleLocksRemovesOrphansAndKeepsLive(t *testing.T) {
+	tempDir := t.TempDir()
+	baseLog := filepath.Join(tempDir, "proxy.log")
+	if err := os.WriteFile(baseLog, []byte("live"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orphanRotate := filepath.Join(tempDir, "proxy.old.log.rotate.lock")
+	orphanSession := filepath.Join(tempDir, "proxy.old.lock")
+	liveRotate := filepath.Join(tempDir, "proxy.log.rotate.lock")
+	if err := os.WriteFile(orphanRotate, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(orphanSession, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(liveRotate, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cleanupIdleLocks(tempDir, baseLog)
+
+	if _, err := os.Stat(orphanRotate); !os.IsNotExist(err) {
+		t.Fatalf("orphan rotate lock was kept: %v", err)
+	}
+	if _, err := os.Stat(orphanSession); !os.IsNotExist(err) {
+		t.Fatalf("orphan session lock was kept: %v", err)
+	}
+	if _, err := os.Stat(liveRotate); err != nil {
+		t.Fatalf("rotate lock for existing log was removed: %v", err)
+	}
+}
+
+func TestCleanupIdleLocksLeavesHeldSessionLock(t *testing.T) {
+	tempDir := t.TempDir()
+	baseLog := filepath.Join(tempDir, "proxy.log")
+	sessionLog := session.GetSessionBasedLogFile(baseLog, "pts_1")
+	lockPath := sessionLockPathForLog(baseLog, sessionLog)
+	held, err := createProcessLock(lockPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanupProcessLock(held, lockPath)
+
+	cleanupIdleLocks(tempDir, baseLog)
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("held session lock was removed: %v", err)
+	}
+}
+
 func TestCleanupOldSessionLogsSkipsLiveExtensionlessSession(t *testing.T) {
 	tempDir := t.TempDir()
 	baseLog := filepath.Join(tempDir, "proxy")

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -103,56 +103,6 @@ func TestSessionLockPathForLogExtensionless(t *testing.T) {
 	}
 }
 
-func TestCleanupIdleLocksRemovesOrphansAndKeepsLive(t *testing.T) {
-	tempDir := t.TempDir()
-	baseLog := filepath.Join(tempDir, "proxy.log")
-	if err := os.WriteFile(baseLog, []byte("live"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	orphanRotate := filepath.Join(tempDir, "proxy.old.log.rotate.lock")
-	orphanSession := filepath.Join(tempDir, "proxy.old.lock")
-	liveRotate := filepath.Join(tempDir, "proxy.log.rotate.lock")
-	if err := os.WriteFile(orphanRotate, nil, 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(orphanSession, nil, 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(liveRotate, nil, 0o600); err != nil {
-		t.Fatal(err)
-	}
-
-	cleanupIdleLocks(tempDir, baseLog)
-
-	if _, err := os.Stat(orphanRotate); !os.IsNotExist(err) {
-		t.Fatalf("orphan rotate lock was kept: %v", err)
-	}
-	if _, err := os.Stat(orphanSession); !os.IsNotExist(err) {
-		t.Fatalf("orphan session lock was kept: %v", err)
-	}
-	if _, err := os.Stat(liveRotate); err != nil {
-		t.Fatalf("rotate lock for existing log was removed: %v", err)
-	}
-}
-
-func TestCleanupIdleLocksLeavesHeldSessionLock(t *testing.T) {
-	tempDir := t.TempDir()
-	baseLog := filepath.Join(tempDir, "proxy.log")
-	sessionLog := session.GetSessionBasedLogFile(baseLog, "pts_1")
-	lockPath := sessionLockPathForLog(baseLog, sessionLog)
-	held, err := createProcessLock(lockPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cleanupProcessLock(held, lockPath)
-
-	cleanupIdleLocks(tempDir, baseLog)
-	if _, err := os.Stat(lockPath); err != nil {
-		t.Fatalf("held session lock was removed: %v", err)
-	}
-}
-
 func TestCleanupOldSessionLogsSkipsLiveExtensionlessSession(t *testing.T) {
 	tempDir := t.TempDir()
 	baseLog := filepath.Join(tempDir, "proxy")

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/xyenon/smart-suggestion/internal/session"
+	"github.com/xyenon/smart-suggestion/pkg"
 )
 
 func TestIsProcessRunning(t *testing.T) {
@@ -328,6 +329,61 @@ func TestRunProxy_PTYError(t *testing.T) {
 	}, strings.NewReader(""), io.Discard)
 	if err == nil {
 		t.Error("expected error for non-existent shell, got nil")
+	}
+}
+
+func TestLineLimitedWriterReopensAfterRotation(t *testing.T) {
+	tempDir := t.TempDir()
+	logPath := filepath.Join(tempDir, "test.log")
+
+	f, err := os.OpenFile(logPath, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatalf("failed to create log file: %v", err)
+	}
+	defer f.Close()
+
+	w := newLineLimitedWriter(f, logPath, 10)
+	if _, err := w.Write([]byte("before\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	lr := pkg.NewLogRotator(&pkg.LogRotateConfig{MaxAge: 1, MaxBackups: 5, Compress: false})
+	if err := lr.ForceRotate(logPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(logPath); !os.IsNotExist(err) {
+		t.Fatalf("expected original log to be renamed, got %v", err)
+	}
+
+	if _, err := w.Write([]byte("after\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(content)
+	if !strings.Contains(got, "after") {
+		t.Fatalf("reopened log missing new content: %q", got)
+	}
+	if !strings.Contains(got, "before") {
+		t.Fatalf("reopened log missing ring buffer: %q", got)
+	}
+
+	backups, err := lr.GetBackupFiles(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(backups) != 1 {
+		t.Fatalf("expected 1 backup, got %d (%v)", len(backups), backups)
+	}
+	backup, err := os.ReadFile(backups[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(backup), "before") {
+		t.Fatalf("backup missing pre-rotation content: %q", backup)
 	}
 }
 

--- a/internal/shellcontext/context.go
+++ b/internal/shellcontext/context.go
@@ -13,6 +13,7 @@ import (
 	"github.com/xyenon/smart-suggestion/internal/debug"
 	"github.com/xyenon/smart-suggestion/internal/paths"
 	"github.com/xyenon/smart-suggestion/internal/session"
+	"github.com/xyenon/smart-suggestion/pkg"
 )
 
 var (
@@ -280,6 +281,16 @@ func readLatestLines(content string, maxLines int) (string, error) {
 }
 
 func readLatestProxyContent(logFile string, maxLines int) (string, error) {
+	var content string
+	err := pkg.WithLogReadLock(logFile, func() error {
+		var err error
+		content, err = readLatestProxyContentUnlocked(logFile, maxLines)
+		return err
+	})
+	return content, err
+}
+
+func readLatestProxyContentUnlocked(logFile string, maxLines int) (string, error) {
 	file, err := os.Open(logFile)
 	if err != nil {
 		return "", fmt.Errorf("failed to open proxy log file: %w", err)

--- a/internal/zsh/integration_test.go
+++ b/internal/zsh/integration_test.go
@@ -993,11 +993,6 @@ func TestUpdateCheckRecoversStaleMkdirLock(t *testing.T) {
 	}
 
 	script := fmt.Sprintf(`
-export SMART_SUGGESTION_CACHE_DIR=%s
-export SMART_SUGGESTION_BINARY=%s
-export SMART_SUGGESTION_AUTO_UPDATE=true
-export SMART_SUGGESTION_UPDATE_INTERVAL=7
-export SMART_SUGGESTION_PROXY_MODE=false
 source %s
 if [[ -d "$SMART_SUGGESTION_CACHE_DIR/update_check.lock" ]]; then
   echo LOCK_STILL_DIR
@@ -1011,7 +1006,7 @@ if [[ -f "$SMART_SUGGESTION_CACHE_DIR/last_update_check" ]]; then
 fi
 source %s
 echo SECOND_SOURCE_OK
-`, cacheDir, mockBinPath, pluginPath, pluginPath)
+`, pluginPath, pluginPath)
 
 	cmd := exec.Command("zsh", "-f", "-c", script)
 	cmd.Dir = projectRoot

--- a/internal/zsh/integration_test.go
+++ b/internal/zsh/integration_test.go
@@ -948,20 +948,18 @@ func TestPluginSecuresExistingCacheFiles(t *testing.T) {
 	}
 	defer session.Close()
 
-	info, err := os.Stat(cacheDir)
-	if err != nil {
-		t.Fatal(err)
+	assertOwnerPrivate := func(path string) {
+		t.Helper()
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if perm := info.Mode().Perm(); perm&0o077 != 0 {
+			t.Fatalf("%s is still accessible by group/other: %o", path, perm)
+		}
 	}
-	if info.Mode().Perm() != 0o700 {
-		t.Fatalf("cache directory permissions are %o, want 700", info.Mode().Perm())
-	}
-	info, err = os.Stat(debugLog)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if info.Mode().Perm() != 0o600 {
-		t.Fatalf("debug log permissions are %o, want 600", info.Mode().Perm())
-	}
+	assertOwnerPrivate(cacheDir)
+	assertOwnerPrivate(debugLog)
 }
 
 func TestConcurrentSuggestionsUseSeparateTempFiles(t *testing.T) {

--- a/internal/zsh/integration_test.go
+++ b/internal/zsh/integration_test.go
@@ -962,6 +962,88 @@ func TestPluginSecuresExistingCacheFiles(t *testing.T) {
 	assertOwnerPrivate(debugLog)
 }
 
+func TestUpdateCheckRecoversStaleMkdirLock(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get wd: %v", err)
+	}
+	projectRoot, err := filepath.Abs(filepath.Join(cwd, "..", ".."))
+	if err != nil {
+		t.Fatalf("Failed to get project root: %v", err)
+	}
+	pluginPath := filepath.Join(projectRoot, "smart-suggestion.plugin.zsh")
+
+	tmpDir := t.TempDir()
+	cacheDir := filepath.Join(tmpDir, "cache")
+	if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	lockPath := filepath.Join(cacheDir, "update_check.lock")
+	if err := os.Mkdir(lockPath, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	mockBinPath := filepath.Join(tmpDir, "smart-suggestion-bin")
+	if err := os.WriteFile(mockBinPath, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	script := fmt.Sprintf(`
+export SMART_SUGGESTION_CACHE_DIR=%s
+export SMART_SUGGESTION_BINARY=%s
+export SMART_SUGGESTION_AUTO_UPDATE=true
+export SMART_SUGGESTION_UPDATE_INTERVAL=7
+export SMART_SUGGESTION_PROXY_MODE=false
+source %s
+if [[ -d "$SMART_SUGGESTION_CACHE_DIR/update_check.lock" ]]; then
+  echo LOCK_STILL_DIR
+elif [[ -f "$SMART_SUGGESTION_CACHE_DIR/update_check.lock" ]]; then
+  echo LOCK_IS_FILE
+else
+  echo LOCK_MISSING
+fi
+if [[ -f "$SMART_SUGGESTION_CACHE_DIR/last_update_check" ]]; then
+  echo UPDATE_CHECKED
+fi
+source %s
+echo SECOND_SOURCE_OK
+`, cacheDir, mockBinPath, pluginPath, pluginPath)
+
+	cmd := exec.Command("zsh", "-f", "-c", script)
+	cmd.Dir = projectRoot
+	cmd.Env = append(os.Environ(),
+		"ZDOTDIR="+tmpDir,
+		"HOME="+tmpDir,
+		"XDG_CACHE_HOME="+tmpDir,
+		"XDG_CONFIG_HOME="+tmpDir,
+		"OPENAI_API_KEY=fake-key",
+		"SMART_SUGGESTION_AI_PROVIDER=openai",
+		"SMART_SUGGESTION_BINARY="+mockBinPath,
+		"SMART_SUGGESTION_CACHE_DIR="+cacheDir,
+		"SMART_SUGGESTION_AUTO_UPDATE=true",
+		"SMART_SUGGESTION_PROXY_MODE=false",
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("Command failed with %v: %s", err, string(out))
+	}
+	output := string(out)
+	if !strings.Contains(output, "LOCK_IS_FILE") {
+		t.Errorf("stale mkdir lock was not recovered. Output:\n%s", output)
+	}
+	if !strings.Contains(output, "UPDATE_CHECKED") {
+		t.Errorf("update check did not run after recovering lock. Output:\n%s", output)
+	}
+	if !strings.Contains(output, "SECOND_SOURCE_OK") {
+		t.Errorf("second source after flock unlock failed. Output:\n%s", output)
+	}
+}
+
 func TestConcurrentSuggestionsUseSeparateTempFiles(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")

--- a/internal/zsh/integration_test.go
+++ b/internal/zsh/integration_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/creack/pty"
 )
 
+const zshAutosuggestionsTag = "v0.7.1"
+
 type zshSession struct {
 	pty    *os.File
 	cmd    *exec.Cmd
@@ -103,6 +105,10 @@ func spawnZsh() (*zshSession, error) {
 }
 
 func spawnZshWithProvider(provider string) (*zshSession, error) {
+	return spawnZshWithProviderAndCache(provider, "")
+}
+
+func spawnZshWithProviderAndCache(provider, cacheHome string) (*zshSession, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, err
@@ -118,8 +124,12 @@ func spawnZshWithProvider(provider string) (*zshSession, error) {
 		return nil, err
 	}
 
+	if cacheHome == "" {
+		cacheHome = tmpDir
+	}
+
 	autosuggestDir := filepath.Join(tmpDir, "zsh-autosuggestions")
-	cloneCmd := exec.Command("git", "clone", "--depth", "1", "https://github.com/zsh-users/zsh-autosuggestions", autosuggestDir)
+	cloneCmd := exec.Command("git", "clone", "--depth", "1", "--branch", zshAutosuggestionsTag, "https://github.com/zsh-users/zsh-autosuggestions", autosuggestDir)
 	if out, err := cloneCmd.CombinedOutput(); err != nil {
 		os.RemoveAll(tmpDir)
 		return nil, fmt.Errorf("failed to clone zsh-autosuggestions: %v, output: %s", err, string(out))
@@ -145,7 +155,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 if [ -f "$MOCK_ERROR_FILE" ]; then
-    cat "$MOCK_ERROR_FILE" > "$XDG_CACHE_HOME/smart-suggestion/error"
+    cat "$MOCK_ERROR_FILE" >&2
     exit 1
 fi
 
@@ -189,7 +199,7 @@ SMART_SUGGESTION_DEBUG="true"
 	cmd.Env = append(os.Environ(),
 		"ZDOTDIR="+tmpDir,
 		"HOME="+tmpDir,
-		"XDG_CACHE_HOME="+tmpDir,
+		"XDG_CACHE_HOME="+cacheHome,
 		"XDG_CONFIG_HOME="+tmpDir,
 		"TERM=xterm-256color",
 		"MOCK_ERROR_FILE="+filepath.Join(tmpDir, "mock_error"),
@@ -878,5 +888,130 @@ func TestProxyStartedInHerdrWithoutPaneID(t *testing.T) {
 
 	if !strings.Contains(output, "PROXY_STARTED:proxy --scrollback-lines 100") {
 		t.Fatalf("Proxy did not start without HERDR_PANE_ID. Output:\n%s", output)
+	}
+}
+
+func TestNumericReplaceSuggestionIsNotReadAsPID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	session, err := spawnZsh()
+	if err != nil {
+		t.Fatalf("Failed to spawn zsh: %v", err)
+	}
+	defer session.Close()
+
+	if err := session.SetMockResponse("=42"); err != nil {
+		t.Fatal(err)
+	}
+
+	session.pty.Write([]byte("echo original"))
+	time.Sleep(200 * time.Millisecond)
+	session.TriggerSuggest()
+	time.Sleep(2 * time.Second)
+
+	if output, err := session.RunCommand("", 5*time.Second); err != nil {
+		t.Fatalf("numeric replace suggestion did not finish: %v. Output: %s", err, output)
+	}
+
+	_, err = session.Expect("42", 5*time.Second)
+	if err != nil {
+		t.Fatalf("numeric replace suggestion was not applied. Output: %s", session.output.String())
+	}
+}
+
+func TestPluginSecuresExistingCacheFiles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	cacheHome := t.TempDir()
+	cacheDir := filepath.Join(cacheHome, "smart-suggestion")
+	if err := os.Mkdir(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	debugLog := filepath.Join(cacheDir, "debug.log")
+	if err := os.WriteFile(debugLog, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(debugLog, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	session, err := spawnZshWithProviderAndCache("openai", cacheHome)
+	if err != nil {
+		t.Fatalf("Failed to spawn zsh: %v", err)
+	}
+	defer session.Close()
+
+	info, err := os.Stat(cacheDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o700 {
+		t.Fatalf("cache directory permissions are %o, want 700", info.Mode().Perm())
+	}
+	info, err = os.Stat(debugLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("debug log permissions are %o, want 600", info.Mode().Perm())
+	}
+}
+
+func TestConcurrentSuggestionsUseSeparateTempFiles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	cacheHome := t.TempDir()
+	first, err := spawnZshWithProviderAndCache("openai", cacheHome)
+	if err != nil {
+		t.Fatalf("Failed to spawn first zsh: %v", err)
+	}
+	defer first.Close()
+	second, err := spawnZshWithProviderAndCache("openai", cacheHome)
+	if err != nil {
+		t.Fatalf("Failed to spawn second zsh: %v", err)
+	}
+	defer second.Close()
+
+	if err := first.SetMockResponse("=echo first_concurrent_suggestion"); err != nil {
+		t.Fatal(err)
+	}
+	if err := first.SetMockDelay(2 * time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if err := second.SetMockResponse("=echo second_concurrent_suggestion"); err != nil {
+		t.Fatal(err)
+	}
+	if err := second.SetMockDelay(2 * time.Second); err != nil {
+		t.Fatal(err)
+	}
+
+	first.pty.Write([]byte("echo first_original"))
+	second.pty.Write([]byte("echo second_original"))
+	time.Sleep(200 * time.Millisecond)
+	first.TriggerSuggest()
+	second.TriggerSuggest()
+
+	firstOutput, err := first.RunCommand("", 8*time.Second)
+	if err != nil {
+		t.Fatalf("first suggestion did not finish: %v. Output: %s", err, firstOutput)
+	}
+	if !strings.Contains(firstOutput, "first_concurrent_suggestion") {
+		t.Fatalf("first shell received the wrong suggestion. Output: %s", firstOutput)
+	}
+	secondOutput, err := second.RunCommand("", 8*time.Second)
+	if err != nil {
+		t.Fatalf("second suggestion did not finish: %v. Output: %s", err, secondOutput)
+	}
+	if !strings.Contains(secondOutput, "second_concurrent_suggestion") {
+		t.Fatalf("second shell received the wrong suggestion. Output: %s", secondOutput)
 	}
 }

--- a/pkg/logrotate.go
+++ b/pkg/logrotate.go
@@ -193,13 +193,6 @@ func WithLogRotateLock(logFilePath string, fn func() error) error {
 // WithLogReadLock takes a shared per-log lock so readers see a complete
 // snapshot instead of a file that is mid-truncate or mid-rewrite.
 func WithLogReadLock(logFilePath string, fn func() error) error {
-	exists, err := fileExists(logFilePath)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		return fn()
-	}
 	return withLogLock(logFilePath, syscall.LOCK_SH, fn)
 }
 

--- a/pkg/logrotate.go
+++ b/pkg/logrotate.go
@@ -88,8 +88,10 @@ func (lr *LogRotator) rotateFile(logFilePath string) error {
 		return err
 	}
 
-	// Move current log file to backup
+	// Move current log file to backup. uniqueBackupPath already reserved
+	// backupPath with O_EXCL so this rename cannot collide with another name.
 	if err := os.Rename(logFilePath, backupPath); err != nil {
+		_ = os.Remove(backupPath)
 		return fmt.Errorf("failed to rename log file %s to %s: %w", logFilePath, backupPath, err)
 	}
 
@@ -142,29 +144,40 @@ func (lr *LogRotator) compressFile(srcPath, dstPath string) error {
 }
 
 func uniqueBackupPath(dir, name, ext string) (string, error) {
-	timestamp := time.Now().Format("20060102-150405")
-	for i := 0; i < 100; i++ {
+	return uniqueBackupPathAt(dir, name, ext, time.Now())
+}
+
+func uniqueBackupPathAt(dir, name, ext string, now time.Time) (string, error) {
+	timestamp := now.Format("20060102-150405")
+	for i := 0; ; i++ {
 		suffix := timestamp
 		if i > 0 {
 			suffix = fmt.Sprintf("%s-%d", timestamp, i)
 		}
 		candidate := filepath.Join(dir, fmt.Sprintf("%s-%s%s", name, suffix, ext))
-		inUse, err := fileExists(candidate)
+
+		// Reserve the name exclusively so a concurrent rotator cannot
+		// observe the same free path and os.Rename over it (TOCTOU).
+		f, err := os.OpenFile(candidate, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 		if err != nil {
+			if os.IsExist(err) {
+				continue
+			}
+			return "", fmt.Errorf("failed to reserve backup name %s: %w", candidate, err)
+		}
+		_ = f.Close()
+
+		inUse, err := fileExists(candidate + ".gz")
+		if err != nil {
+			_ = os.Remove(candidate)
 			return "", err
 		}
 		if inUse {
+			_ = os.Remove(candidate)
 			continue
 		}
-		inUse, err = fileExists(candidate + ".gz")
-		if err != nil {
-			return "", err
-		}
-		if !inUse {
-			return candidate, nil
-		}
+		return candidate, nil
 	}
-	return "", fmt.Errorf("failed to allocate unique backup name for %s-%s%s", name, timestamp, ext)
 }
 
 func fileExists(path string) (bool, error) {

--- a/pkg/logrotate.go
+++ b/pkg/logrotate.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -57,23 +58,19 @@ func (lr *LogRotator) CheckAndRotate(logFilePath string) error {
 	lr.mutex.Lock()
 	defer lr.mutex.Unlock()
 
-	// Check if file exists and get its size
-	fileInfo, err := os.Stat(logFilePath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			// File doesn't exist, no need to rotate
+	return withLogRotateLock(logFilePath, func() error {
+		fileInfo, err := os.Stat(logFilePath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("failed to stat log file %s: %w", logFilePath, err)
+		}
+		if fileInfo.Size() < lr.config.MaxSize {
 			return nil
 		}
-		return fmt.Errorf("failed to stat log file %s: %w", logFilePath, err)
-	}
-
-	// Check if rotation is needed
-	if fileInfo.Size() < lr.config.MaxSize {
-		return nil
-	}
-
-	// Perform rotation
-	return lr.rotateFile(logFilePath)
+		return lr.rotateFile(logFilePath)
+	})
 }
 
 // rotateFile performs the actual file rotation
@@ -167,6 +164,30 @@ func (lr *LogRotator) compressReader(src io.Reader, dstPath string) (err error) 
 
 func backupReservationPath(backupPath string) string {
 	return backupPath + ".reserving"
+}
+
+func logRotateLockPath(logFilePath string) string {
+	return logFilePath + ".rotate.lock"
+}
+
+// withLogRotateLock serializes rotate → compress → cleanup for one log
+// across processes. Leftover .reserving / .gz.tmp.* files are only removed
+// while this exclusive lock is held, so a live reservation cannot be deleted.
+func withLogRotateLock(logFilePath string, fn func() error) error {
+	lockPath := logRotateLockPath(logFilePath)
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fn()
+		}
+		return fmt.Errorf("failed to open rotation lock %s: %w", lockPath, err)
+	}
+	defer f.Close()
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		return fmt.Errorf("failed to acquire rotation lock %s: %w", lockPath, err)
+	}
+	defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+	return fn()
 }
 
 func uniqueBackupPath(dir, name, ext string) (string, error) {
@@ -271,6 +292,9 @@ func findBackupFiles(dir, name, ext string) ([]string, error) {
 	return backups, nil
 }
 
+// cleanupStaleRotationFiles removes leftover reservation and gzip temp files.
+// It must only run while holding the per-log rotation lock, so matching files
+// belong to a previous crashed rotation of this log, not a live one.
 func cleanupStaleRotationFiles(dir, name, ext string) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -353,15 +377,15 @@ func (lr *LogRotator) ForceRotate(logFilePath string) error {
 	lr.mutex.Lock()
 	defer lr.mutex.Unlock()
 
-	// Check if file exists
-	if _, err := os.Stat(logFilePath); err != nil {
-		if os.IsNotExist(err) {
-			return nil // File doesn't exist, nothing to rotate
+	return withLogRotateLock(logFilePath, func() error {
+		if _, err := os.Stat(logFilePath); err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return fmt.Errorf("failed to stat log file %s: %w", logFilePath, err)
 		}
-		return fmt.Errorf("failed to stat log file %s: %w", logFilePath, err)
-	}
-
-	return lr.rotateFile(logFilePath)
+		return lr.rotateFile(logFilePath)
+	})
 }
 
 // GetBackupFiles returns a list of backup files for the given log file

--- a/pkg/logrotate.go
+++ b/pkg/logrotate.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -77,16 +78,15 @@ func (lr *LogRotator) CheckAndRotate(logFilePath string) error {
 
 // rotateFile performs the actual file rotation
 func (lr *LogRotator) rotateFile(logFilePath string) error {
-	// Generate timestamp for the backup file
-	timestamp := time.Now().Format("20060102-150405")
-
-	// Create backup filename
 	dir := filepath.Dir(logFilePath)
 	base := filepath.Base(logFilePath)
 	ext := filepath.Ext(base)
 	name := strings.TrimSuffix(base, ext)
 
-	backupPath := filepath.Join(dir, fmt.Sprintf("%s-%s%s", name, timestamp, ext))
+	backupPath, err := uniqueBackupPath(dir, name, ext)
+	if err != nil {
+		return err
+	}
 
 	// Move current log file to backup
 	if err := os.Rename(logFilePath, backupPath); err != nil {
@@ -130,13 +130,71 @@ func (lr *LogRotator) compressFile(srcPath, dstPath string) error {
 	defer dstFile.Close()
 
 	gzipWriter := gzip.NewWriter(dstFile)
-	defer gzipWriter.Close()
-
 	if _, err := io.Copy(gzipWriter, srcFile); err != nil {
+		_ = gzipWriter.Close()
 		return fmt.Errorf("failed to compress file: %w", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		return fmt.Errorf("failed to close gzip writer for %s: %w", dstPath, err)
 	}
 
 	return nil
+}
+
+func uniqueBackupPath(dir, name, ext string) (string, error) {
+	timestamp := time.Now().Format("20060102-150405")
+	for i := 0; i < 100; i++ {
+		suffix := timestamp
+		if i > 0 {
+			suffix = fmt.Sprintf("%s-%d", timestamp, i)
+		}
+		candidate := filepath.Join(dir, fmt.Sprintf("%s-%s%s", name, suffix, ext))
+		inUse, err := fileExists(candidate)
+		if err != nil {
+			return "", err
+		}
+		if inUse {
+			continue
+		}
+		inUse, err = fileExists(candidate + ".gz")
+		if err != nil {
+			return "", err
+		}
+		if !inUse {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("failed to allocate unique backup name for %s-%s%s", name, timestamp, ext)
+}
+
+func fileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func findBackupFiles(dir, name, ext string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read backup directory %s: %w", dir, err)
+	}
+
+	pattern := regexp.MustCompile(`^` + regexp.QuoteMeta(name) + `-[0-9]{8}-[0-9]{6}(-[1-9][0-9]*)?` + regexp.QuoteMeta(ext) + `(\.gz)?$`)
+	backups := make([]string, 0)
+	for _, entry := range entries {
+		if !entry.IsDir() && pattern.MatchString(entry.Name()) {
+			backups = append(backups, filepath.Join(dir, entry.Name()))
+		}
+	}
+	return backups, nil
 }
 
 // cleanupOldBackups removes old backup files based on MaxBackups and MaxAge settings
@@ -146,11 +204,9 @@ func (lr *LogRotator) cleanupOldBackups(logFilePath string) error {
 	ext := filepath.Ext(base)
 	name := strings.TrimSuffix(base, ext)
 
-	// Find all backup files
-	pattern := filepath.Join(dir, fmt.Sprintf("%s-*%s*", name, ext))
-	matches, err := filepath.Glob(pattern)
+	matches, err := findBackupFiles(dir, name, ext)
 	if err != nil {
-		return fmt.Errorf("failed to find backup files with pattern %s: %w", pattern, err)
+		return fmt.Errorf("failed to find backup files for %s: %w", logFilePath, err)
 	}
 
 	// Create a list of backup files with their info
@@ -223,11 +279,9 @@ func (lr *LogRotator) GetBackupFiles(logFilePath string) ([]string, error) {
 	ext := filepath.Ext(base)
 	name := strings.TrimSuffix(base, ext)
 
-	// Find all backup files
-	pattern := filepath.Join(dir, fmt.Sprintf("%s-*%s*", name, ext))
-	matches, err := filepath.Glob(pattern)
+	matches, err := findBackupFiles(dir, name, ext)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find backup files with pattern %s: %w", pattern, err)
+		return nil, fmt.Errorf("failed to find backup files for %s: %w", logFilePath, err)
 	}
 
 	// Filter out the current log file

--- a/pkg/logrotate.go
+++ b/pkg/logrotate.go
@@ -58,12 +58,9 @@ func (lr *LogRotator) CheckAndRotate(logFilePath string) error {
 	lr.mutex.Lock()
 	defer lr.mutex.Unlock()
 
-	return withLogRotateLock(logFilePath, func() error {
+	return lr.withLockedLog(logFilePath, func() error {
 		fileInfo, err := os.Stat(logFilePath)
 		if err != nil {
-			if os.IsNotExist(err) {
-				return nil
-			}
 			return fmt.Errorf("failed to stat log file %s: %w", logFilePath, err)
 		}
 		if fileInfo.Size() < lr.config.MaxSize {
@@ -142,22 +139,18 @@ func (lr *LogRotator) compressReader(src io.Reader, dstPath string) (err error) 
 	}()
 
 	gzipWriter := gzip.NewWriter(tmpFile)
-	if _, copyErr := io.Copy(gzipWriter, src); copyErr != nil {
+	if _, err = io.Copy(gzipWriter, src); err != nil {
 		_ = gzipWriter.Close()
-		err = fmt.Errorf("failed to compress file: %w", copyErr)
-		return err
+		return fmt.Errorf("failed to compress file: %w", err)
 	}
-	if closeErr := gzipWriter.Close(); closeErr != nil {
-		err = fmt.Errorf("failed to close gzip writer for %s: %w", dstPath, closeErr)
-		return err
+	if err = gzipWriter.Close(); err != nil {
+		return fmt.Errorf("failed to close gzip writer for %s: %w", dstPath, err)
 	}
-	if closeErr := tmpFile.Close(); closeErr != nil {
-		err = fmt.Errorf("failed to close temporary compressed file %s: %w", tmpPath, closeErr)
-		return err
+	if err = tmpFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temporary compressed file %s: %w", tmpPath, err)
 	}
-	if renameErr := os.Rename(tmpPath, dstPath); renameErr != nil {
-		err = fmt.Errorf("failed to finalize compressed file %s: %w", dstPath, renameErr)
-		return err
+	if err = os.Rename(tmpPath, dstPath); err != nil {
+		return fmt.Errorf("failed to finalize compressed file %s: %w", dstPath, err)
 	}
 	return nil
 }
@@ -170,16 +163,36 @@ func logRotateLockPath(logFilePath string) string {
 	return logFilePath + ".rotate.lock"
 }
 
-// withLogRotateLock serializes rotate → compress → cleanup for one log
-// across processes. Leftover .reserving / .gz.tmp.* files are only removed
-// while this exclusive lock is held, so a live reservation cannot be deleted.
-func withLogRotateLock(logFilePath string, fn func() error) error {
+func (lr *LogRotator) withLockedLog(logFilePath string, fn func() error) error {
+	missing, err := logMissing(logFilePath)
+	if err != nil || missing {
+		return err
+	}
+	return WithLogRotateLock(logFilePath, func() error {
+		missing, err := logMissing(logFilePath)
+		if err != nil || missing {
+			return err
+		}
+		return fn()
+	})
+}
+
+func logMissing(logFilePath string) (bool, error) {
+	exists, err := fileExists(logFilePath)
+	if err != nil {
+		return false, fmt.Errorf("failed to stat log file %s: %w", logFilePath, err)
+	}
+	return !exists, nil
+}
+
+// WithLogRotateLock serializes rotate → compress → cleanup and live writers
+// for one log across processes. The proxy writer holds this lock around each
+// flush so it can reopen the log fd after a rename instead of writing to an
+// unlinked inode.
+func WithLogRotateLock(logFilePath string, fn func() error) error {
 	lockPath := logRotateLockPath(logFilePath)
 	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return fn()
-		}
 		return fmt.Errorf("failed to open rotation lock %s: %w", lockPath, err)
 	}
 	defer f.Close()
@@ -216,17 +229,10 @@ func uniqueBackupPathAt(dir, name, ext string, now time.Time) (string, error) {
 		}
 		_ = f.Close()
 
-		inUse, err := fileExists(candidate)
+		inUse, err := backupNameInUse(candidate)
 		if err != nil {
 			_ = os.Remove(reservation)
 			return "", err
-		}
-		if !inUse {
-			inUse, err = fileExists(candidate + ".gz")
-			if err != nil {
-				_ = os.Remove(reservation)
-				return "", err
-			}
 		}
 		if inUse {
 			_ = os.Remove(reservation)
@@ -234,6 +240,14 @@ func uniqueBackupPathAt(dir, name, ext string, now time.Time) (string, error) {
 		}
 		return candidate, nil
 	}
+}
+
+func backupNameInUse(candidate string) (bool, error) {
+	inUse, err := fileExists(candidate)
+	if err != nil || inUse {
+		return inUse, err
+	}
+	return fileExists(candidate + ".gz")
 }
 
 func fileExists(path string) (bool, error) {
@@ -376,14 +390,7 @@ func (lr *LogRotator) cleanupOldBackups(logFilePath string) error {
 func (lr *LogRotator) ForceRotate(logFilePath string) error {
 	lr.mutex.Lock()
 	defer lr.mutex.Unlock()
-
-	return withLogRotateLock(logFilePath, func() error {
-		if _, err := os.Stat(logFilePath); err != nil {
-			if os.IsNotExist(err) {
-				return nil
-			}
-			return fmt.Errorf("failed to stat log file %s: %w", logFilePath, err)
-		}
+	return lr.withLockedLog(logFilePath, func() error {
 		return lr.rotateFile(logFilePath)
 	})
 }

--- a/pkg/logrotate.go
+++ b/pkg/logrotate.go
@@ -130,6 +130,8 @@ func (lr *LogRotator) compressFile(srcPath, dstPath string) (err error) {
 }
 
 func (lr *LogRotator) compressReader(src io.Reader, dstPath string) (err error) {
+	// Create the temp file in the destination directory so the final rename
+	// stays on the same filesystem and cannot fail with EXDEV.
 	tmpFile, err := os.CreateTemp(filepath.Dir(dstPath), filepath.Base(dstPath)+".tmp.")
 	if err != nil {
 		return fmt.Errorf("failed to create temporary compressed file for %s: %w", dstPath, err)
@@ -224,6 +226,32 @@ func fileExists(path string) (bool, error) {
 	return false, err
 }
 
+func backupFilePattern(name, ext string) *regexp.Regexp {
+	return regexp.MustCompile(`^` + regexp.QuoteMeta(name) + `-([0-9]{8}-[0-9]{6})(?:-([1-9][0-9]*))?` + regexp.QuoteMeta(ext) + `(?:\.gz)?$`)
+}
+
+func rotationTempFilePattern(name, ext string) *regexp.Regexp {
+	return regexp.MustCompile(`^` + regexp.QuoteMeta(name) + `-[0-9]{8}-[0-9]{6}(?:-[1-9][0-9]*)?` + regexp.QuoteMeta(ext) + `(?:\.reserving|\.gz\.tmp\..+)$`)
+}
+
+func parseBackupStamp(filename, name, ext string) (stamp time.Time, seq int, ok bool) {
+	m := backupFilePattern(name, ext).FindStringSubmatch(filename)
+	if m == nil {
+		return time.Time{}, 0, false
+	}
+	stamp, err := time.ParseInLocation("20060102-150405", m[1], time.Local)
+	if err != nil {
+		return time.Time{}, 0, false
+	}
+	if m[2] != "" {
+		seq, err = strconv.Atoi(m[2])
+		if err != nil {
+			return time.Time{}, 0, false
+		}
+	}
+	return stamp, seq, true
+}
+
 func findBackupFiles(dir, name, ext string) ([]string, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -233,7 +261,7 @@ func findBackupFiles(dir, name, ext string) ([]string, error) {
 		return nil, fmt.Errorf("failed to read backup directory %s: %w", dir, err)
 	}
 
-	pattern := regexp.MustCompile(`^` + regexp.QuoteMeta(name) + `-[0-9]{8}-[0-9]{6}(-[1-9][0-9]*)?` + regexp.QuoteMeta(ext) + `(\.gz)?$`)
+	pattern := backupFilePattern(name, ext)
 	backups := make([]string, 0)
 	for _, entry := range entries {
 		if !entry.IsDir() && pattern.MatchString(entry.Name()) {
@@ -243,6 +271,20 @@ func findBackupFiles(dir, name, ext string) ([]string, error) {
 	return backups, nil
 }
 
+func cleanupStaleRotationFiles(dir, name, ext string) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	pattern := rotationTempFilePattern(name, ext)
+	for _, entry := range entries {
+		if entry.IsDir() || !pattern.MatchString(entry.Name()) {
+			continue
+		}
+		_ = os.Remove(filepath.Join(dir, entry.Name()))
+	}
+}
+
 // cleanupOldBackups removes old backup files based on MaxBackups and MaxAge settings
 func (lr *LogRotator) cleanupOldBackups(logFilePath string) error {
 	dir := filepath.Dir(logFilePath)
@@ -250,46 +292,50 @@ func (lr *LogRotator) cleanupOldBackups(logFilePath string) error {
 	ext := filepath.Ext(base)
 	name := strings.TrimSuffix(base, ext)
 
+	cleanupStaleRotationFiles(dir, name, ext)
+
 	matches, err := findBackupFiles(dir, name, ext)
 	if err != nil {
 		return fmt.Errorf("failed to find backup files for %s: %w", logFilePath, err)
 	}
 
-	// Create a list of backup files with their info
 	type backupFile struct {
-		path    string
-		modTime time.Time
+		path string
+		when time.Time
+		seq  int
 	}
 
 	var backups []backupFile
 	cutoffTime := time.Now().AddDate(0, 0, -lr.config.MaxAge)
 
 	for _, match := range matches {
-		// Skip the current log file
 		if match == logFilePath {
 			continue
 		}
 
-		fileInfo, err := os.Stat(match)
-		if err != nil {
+		stamp, seq, ok := parseBackupStamp(filepath.Base(match), name, ext)
+		if !ok {
 			continue
 		}
 
-		// Remove files older than MaxAge
-		if fileInfo.ModTime().Before(cutoffTime) {
+		if stamp.Before(cutoffTime) {
 			os.Remove(match)
 			continue
 		}
 
 		backups = append(backups, backupFile{
-			path:    match,
-			modTime: fileInfo.ModTime(),
+			path: match,
+			when: stamp,
+			seq:  seq,
 		})
 	}
 
-	// Sort by modification time (newest first)
+	// Newest rotation first. Same-second backups use the numeric suffix.
 	sort.Slice(backups, func(i, j int) bool {
-		return backups[i].modTime.After(backups[j].modTime)
+		if backups[i].when.Equal(backups[j].when) {
+			return backups[i].seq > backups[j].seq
+		}
+		return backups[i].when.After(backups[j].when)
 	})
 
 	// Remove excess backup files

--- a/pkg/logrotate.go
+++ b/pkg/logrotate.go
@@ -210,43 +210,6 @@ func withLogLock(logFilePath string, how int, fn func() error) error {
 	return fn()
 }
 
-// RemoveIdleLock unlinks lockPath only after acquiring an exclusive flock on
-// that inode and confirming the path still names it. A held lock is left
-// untouched, so this cannot replace a live flock inode.
-func RemoveIdleLock(lockPath string) error {
-	f, err := os.OpenFile(lockPath, os.O_RDWR, 0)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	defer f.Close()
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
-		return nil
-	}
-	defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
-
-	fdInfo, err := f.Stat()
-	if err != nil {
-		return err
-	}
-	pathInfo, err := os.Stat(lockPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-	if !os.SameFile(fdInfo, pathInfo) {
-		return nil
-	}
-	if err := os.Remove(lockPath); err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	return nil
-}
-
 func uniqueBackupPath(dir, name, ext string) (string, error) {
 	return uniqueBackupPathAt(dir, name, ext, time.Now())
 }

--- a/pkg/logrotate.go
+++ b/pkg/logrotate.go
@@ -88,12 +88,11 @@ func (lr *LogRotator) rotateFile(logFilePath string) error {
 		return err
 	}
 
-	// Move current log file to backup. uniqueBackupPath already reserved
-	// backupPath with O_EXCL so this rename cannot collide with another name.
 	if err := os.Rename(logFilePath, backupPath); err != nil {
-		_ = os.Remove(backupPath)
+		_ = os.Remove(backupReservationPath(backupPath))
 		return fmt.Errorf("failed to rename log file %s to %s: %w", logFilePath, backupPath, err)
 	}
+	_ = os.Remove(backupReservationPath(backupPath))
 
 	// Compress the backup file if enabled
 	if lr.config.Compress {
@@ -117,30 +116,55 @@ func (lr *LogRotator) rotateFile(logFilePath string) error {
 	return nil
 }
 
-// compressFile compresses the source file to the destination using gzip
-func (lr *LogRotator) compressFile(srcPath, dstPath string) error {
-	srcFile, err := os.Open(srcPath)
+// compressFile compresses the source file to the destination using gzip.
+// The destination is replaced only after a complete gzip stream is written,
+// so a failed compress cannot leave a partial .gz that cleanup would treat
+// as a real backup.
+func (lr *LogRotator) compressFile(srcPath, dstPath string) (err error) {
+	src, err := os.Open(srcPath)
 	if err != nil {
 		return fmt.Errorf("failed to open source file %s: %w", srcPath, err)
 	}
-	defer srcFile.Close()
+	defer src.Close()
+	return lr.compressReader(src, dstPath)
+}
 
-	dstFile, err := os.Create(dstPath)
+func (lr *LogRotator) compressReader(src io.Reader, dstPath string) (err error) {
+	tmpFile, err := os.CreateTemp(filepath.Dir(dstPath), filepath.Base(dstPath)+".tmp.")
 	if err != nil {
-		return fmt.Errorf("failed to create destination file %s: %w", dstPath, err)
+		return fmt.Errorf("failed to create temporary compressed file for %s: %w", dstPath, err)
 	}
-	defer dstFile.Close()
+	tmpPath := tmpFile.Name()
+	defer func() {
+		_ = tmpFile.Close()
+		if err != nil {
+			_ = os.Remove(tmpPath)
+		}
+	}()
 
-	gzipWriter := gzip.NewWriter(dstFile)
-	if _, err := io.Copy(gzipWriter, srcFile); err != nil {
+	gzipWriter := gzip.NewWriter(tmpFile)
+	if _, copyErr := io.Copy(gzipWriter, src); copyErr != nil {
 		_ = gzipWriter.Close()
-		return fmt.Errorf("failed to compress file: %w", err)
+		err = fmt.Errorf("failed to compress file: %w", copyErr)
+		return err
 	}
-	if err := gzipWriter.Close(); err != nil {
-		return fmt.Errorf("failed to close gzip writer for %s: %w", dstPath, err)
+	if closeErr := gzipWriter.Close(); closeErr != nil {
+		err = fmt.Errorf("failed to close gzip writer for %s: %w", dstPath, closeErr)
+		return err
 	}
-
+	if closeErr := tmpFile.Close(); closeErr != nil {
+		err = fmt.Errorf("failed to close temporary compressed file %s: %w", tmpPath, closeErr)
+		return err
+	}
+	if renameErr := os.Rename(tmpPath, dstPath); renameErr != nil {
+		err = fmt.Errorf("failed to finalize compressed file %s: %w", dstPath, renameErr)
+		return err
+	}
 	return nil
+}
+
+func backupReservationPath(backupPath string) string {
+	return backupPath + ".reserving"
 }
 
 func uniqueBackupPath(dir, name, ext string) (string, error) {
@@ -155,10 +179,12 @@ func uniqueBackupPathAt(dir, name, ext string, now time.Time) (string, error) {
 			suffix = fmt.Sprintf("%s-%d", timestamp, i)
 		}
 		candidate := filepath.Join(dir, fmt.Sprintf("%s-%s%s", name, suffix, ext))
+		reservation := backupReservationPath(candidate)
 
-		// Reserve the name exclusively so a concurrent rotator cannot
-		// observe the same free path and os.Rename over it (TOCTOU).
-		f, err := os.OpenFile(candidate, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		// Claim the candidate with a sidecar. Using the final backup path
+		// itself would make findBackupFiles/cleanupOldBackups treat a
+		// zero-byte reservation as a real backup.
+		f, err := os.OpenFile(reservation, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 		if err != nil {
 			if os.IsExist(err) {
 				continue
@@ -167,13 +193,20 @@ func uniqueBackupPathAt(dir, name, ext string, now time.Time) (string, error) {
 		}
 		_ = f.Close()
 
-		inUse, err := fileExists(candidate + ".gz")
+		inUse, err := fileExists(candidate)
 		if err != nil {
-			_ = os.Remove(candidate)
+			_ = os.Remove(reservation)
 			return "", err
 		}
+		if !inUse {
+			inUse, err = fileExists(candidate + ".gz")
+			if err != nil {
+				_ = os.Remove(reservation)
+				return "", err
+			}
+		}
 		if inUse {
-			_ = os.Remove(candidate)
+			_ = os.Remove(reservation)
 			continue
 		}
 		return candidate, nil

--- a/pkg/logrotate.go
+++ b/pkg/logrotate.go
@@ -81,12 +81,11 @@ func (lr *LogRotator) rotateFile(logFilePath string) error {
 	if err != nil {
 		return err
 	}
+	defer os.Remove(backupReservationPath(backupPath))
 
 	if err := os.Rename(logFilePath, backupPath); err != nil {
-		_ = os.Remove(backupReservationPath(backupPath))
 		return fmt.Errorf("failed to rename log file %s to %s: %w", logFilePath, backupPath, err)
 	}
-	_ = os.Remove(backupReservationPath(backupPath))
 
 	// Compress the backup file if enabled
 	if lr.config.Compress {
@@ -185,18 +184,33 @@ func logMissing(logFilePath string) (bool, error) {
 	return !exists, nil
 }
 
-// WithLogRotateLock serializes rotate → compress → cleanup and live writers
-// for one log across processes. The proxy writer holds this lock around each
-// flush so it can reopen the log fd after a rename instead of writing to an
-// unlinked inode.
+// WithLogRotateLock takes an exclusive per-log lock for rotate → compress →
+// cleanup and for live writers that truncate/rewrite the file.
 func WithLogRotateLock(logFilePath string, fn func() error) error {
+	return withLogLock(logFilePath, syscall.LOCK_EX, fn)
+}
+
+// WithLogReadLock takes a shared per-log lock so readers see a complete
+// snapshot instead of a file that is mid-truncate or mid-rewrite.
+func WithLogReadLock(logFilePath string, fn func() error) error {
+	exists, err := fileExists(logFilePath)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fn()
+	}
+	return withLogLock(logFilePath, syscall.LOCK_SH, fn)
+}
+
+func withLogLock(logFilePath string, how int, fn func() error) error {
 	lockPath := logRotateLockPath(logFilePath)
 	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to open rotation lock %s: %w", lockPath, err)
 	}
 	defer f.Close()
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+	if err := syscall.Flock(int(f.Fd()), how); err != nil {
 		return fmt.Errorf("failed to acquire rotation lock %s: %w", lockPath, err)
 	}
 	defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
@@ -230,16 +244,34 @@ func uniqueBackupPathAt(dir, name, ext string, now time.Time) (string, error) {
 		_ = f.Close()
 
 		inUse, err := backupNameInUse(candidate)
-		if err != nil {
+		if err != nil || inUse {
 			_ = os.Remove(reservation)
-			return "", err
-		}
-		if inUse {
-			_ = os.Remove(reservation)
+			if err != nil {
+				return "", err
+			}
 			continue
 		}
 		return candidate, nil
 	}
+}
+
+func preferCompressedBackup(paths []string) string {
+	for _, path := range paths {
+		if strings.HasSuffix(path, ".gz") {
+			return path
+		}
+	}
+	return paths[0]
+}
+
+func keepOneBackup(paths []string) string {
+	kept := preferCompressedBackup(paths)
+	for _, path := range paths {
+		if path != kept {
+			os.Remove(path)
+		}
+	}
+	return kept
 }
 
 func backupNameInUse(candidate string) (bool, error) {
@@ -337,13 +369,17 @@ func (lr *LogRotator) cleanupOldBackups(logFilePath string) error {
 		return fmt.Errorf("failed to find backup files for %s: %w", logFilePath, err)
 	}
 
+	type backupKey struct {
+		when time.Time
+		seq  int
+	}
 	type backupFile struct {
 		path string
 		when time.Time
 		seq  int
 	}
 
-	var backups []backupFile
+	grouped := make(map[backupKey][]string)
 	cutoffTime := time.Now().AddDate(0, 0, -lr.config.MaxAge)
 
 	for _, match := range matches {
@@ -361,10 +397,16 @@ func (lr *LogRotator) cleanupOldBackups(logFilePath string) error {
 			continue
 		}
 
+		key := backupKey{when: stamp, seq: seq}
+		grouped[key] = append(grouped[key], match)
+	}
+
+	var backups []backupFile
+	for key, paths := range grouped {
 		backups = append(backups, backupFile{
-			path: match,
-			when: stamp,
-			seq:  seq,
+			path: keepOneBackup(paths),
+			when: key.when,
+			seq:  key.seq,
 		})
 	}
 

--- a/pkg/logrotate.go
+++ b/pkg/logrotate.go
@@ -228,37 +228,35 @@ func uniqueBackupPathAt(dir, name, ext string, now time.Time) (string, error) {
 		// itself would make findBackupFiles/cleanupOldBackups treat a
 		// zero-byte reservation as a real backup.
 		f, err := os.OpenFile(reservation, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if os.IsExist(err) {
+			continue
+		}
 		if err != nil {
-			if os.IsExist(err) {
-				continue
-			}
 			return "", fmt.Errorf("failed to reserve backup name %s: %w", candidate, err)
 		}
 		_ = f.Close()
 
 		inUse, err := backupNameInUse(candidate)
-		if err != nil || inUse {
+		if err != nil {
 			_ = os.Remove(reservation)
-			if err != nil {
-				return "", err
-			}
+			return "", err
+		}
+		if inUse {
+			_ = os.Remove(reservation)
 			continue
 		}
 		return candidate, nil
 	}
 }
 
-func preferCompressedBackup(paths []string) string {
+func keepOneBackup(paths []string) string {
+	kept := paths[0]
 	for _, path := range paths {
 		if strings.HasSuffix(path, ".gz") {
-			return path
+			kept = path
+			break
 		}
 	}
-	return paths[0]
-}
-
-func keepOneBackup(paths []string) string {
-	kept := preferCompressedBackup(paths)
 	for _, path := range paths {
 		if path != kept {
 			os.Remove(path)

--- a/pkg/logrotate.go
+++ b/pkg/logrotate.go
@@ -210,6 +210,43 @@ func withLogLock(logFilePath string, how int, fn func() error) error {
 	return fn()
 }
 
+// RemoveIdleLock unlinks lockPath only after acquiring an exclusive flock on
+// that inode and confirming the path still names it. A held lock is left
+// untouched, so this cannot replace a live flock inode.
+func RemoveIdleLock(lockPath string) error {
+	f, err := os.OpenFile(lockPath, os.O_RDWR, 0)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	defer f.Close()
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		return nil
+	}
+	defer syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+
+	fdInfo, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	pathInfo, err := os.Stat(lockPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if !os.SameFile(fdInfo, pathInfo) {
+		return nil
+	}
+	if err := os.Remove(lockPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
 func uniqueBackupPath(dir, name, ext string) (string, error) {
 	return uniqueBackupPathAt(dir, name, ext, time.Now())
 }

--- a/pkg/logrotate_test.go
+++ b/pkg/logrotate_test.go
@@ -167,41 +167,6 @@ func TestLogRotator_Compression(t *testing.T) {
 	}
 }
 
-func TestRemoveIdleLockLeavesHeldLock(t *testing.T) {
-	tempDir := t.TempDir()
-	lockPath := filepath.Join(tempDir, "test.log.rotate.lock")
-	held, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer held.Close()
-	if err := syscall.Flock(int(held.Fd()), syscall.LOCK_EX); err != nil {
-		t.Fatal(err)
-	}
-	defer syscall.Flock(int(held.Fd()), syscall.LOCK_UN)
-
-	if err := RemoveIdleLock(lockPath); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := os.Stat(lockPath); err != nil {
-		t.Fatalf("held lock was removed: %v", err)
-	}
-}
-
-func TestRemoveIdleLockRemovesUnlockedLock(t *testing.T) {
-	tempDir := t.TempDir()
-	lockPath := filepath.Join(tempDir, "test.log.rotate.lock")
-	if err := os.WriteFile(lockPath, nil, 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if err := RemoveIdleLock(lockPath); err != nil {
-		t.Fatal(err)
-	}
-	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
-		t.Fatalf("idle lock was kept: %v", err)
-	}
-}
-
 func TestRotateWaitsForPerLogLock(t *testing.T) {
 	tempDir := t.TempDir()
 	logFile := filepath.Join(tempDir, "test.log")

--- a/pkg/logrotate_test.go
+++ b/pkg/logrotate_test.go
@@ -1,6 +1,8 @@
 package pkg
 
 import (
+	"compress/gzip"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -143,5 +145,100 @@ func TestLogRotator_Compression(t *testing.T) {
 		t.Errorf("expected 1 backup, got %d", len(backups))
 	} else if filepath.Ext(backups[0]) != ".gz" {
 		t.Errorf("expected backup to have .gz extension, got %s", filepath.Ext(backups[0]))
+	}
+}
+
+func TestLogRotator_SameSecondBackupNames(t *testing.T) {
+	tempDir := t.TempDir()
+	logFile := filepath.Join(tempDir, "test.log")
+	lr := NewLogRotator(&LogRotateConfig{MaxSize: 1, MaxBackups: 5, MaxAge: 1, Compress: false})
+
+	for i := 0; i < 3; i++ {
+		if err := os.WriteFile(logFile, []byte("content"), 0o644); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+		if err := lr.CheckAndRotate(logFile); err != nil {
+			t.Fatalf("rotation %d: %v", i, err)
+		}
+	}
+
+	backups, err := lr.GetBackupFiles(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(backups) != 3 {
+		t.Fatalf("expected 3 backups, got %d (%v)", len(backups), backups)
+	}
+}
+
+func TestLogRotator_BackupMatchingIgnoresUnrelatedFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	logFile := filepath.Join(tempDir, "test.log")
+	unrelatedFiles := []string{
+		filepath.Join(tempDir, "test-notes.txt"),
+		filepath.Join(tempDir, "test-20260829-123456-not-a-backup.log.bak"),
+	}
+	oldTime := time.Now().Add(-48 * time.Hour)
+	for _, path := range unrelatedFiles {
+		if err := os.WriteFile(path, []byte("nope"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(path, oldTime, oldTime); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	lr := NewLogRotator(&LogRotateConfig{MaxSize: 1, MaxBackups: 1, MaxAge: 1, Compress: false})
+	if err := os.WriteFile(logFile, []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := lr.CheckAndRotate(logFile); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range unrelatedFiles {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("unrelated file %s was removed: %v", path, err)
+		}
+	}
+
+	backups, err := lr.GetBackupFiles(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(backups) != 1 {
+		t.Fatalf("expected 1 backup, got %d (%v)", len(backups), backups)
+	}
+}
+
+func TestCompressFileClosesGzipWriter(t *testing.T) {
+	tempDir := t.TempDir()
+	src := filepath.Join(tempDir, "src.log")
+	dst := filepath.Join(tempDir, "src.log.gz")
+	if err := os.WriteFile(src, []byte("compress me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lr := NewLogRotator(nil)
+	if err := lr.compressFile(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := os.Open(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	gr, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatalf("gzip footer missing: %v", err)
+	}
+	defer gr.Close()
+	got, err := io.ReadAll(gr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "compress me" {
+		t.Fatalf("got %q", got)
 	}
 }

--- a/pkg/logrotate_test.go
+++ b/pkg/logrotate_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -150,6 +151,28 @@ func TestLogRotator_Compression(t *testing.T) {
 	}
 }
 
+func TestRotateRemovesReservationSidecar(t *testing.T) {
+	tempDir := t.TempDir()
+	logFile := filepath.Join(tempDir, "test.log")
+	lr := NewLogRotator(&LogRotateConfig{MaxSize: 1, MaxBackups: 5, MaxAge: 1, Compress: false})
+	if err := os.WriteFile(logFile, []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := lr.CheckAndRotate(logFile); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := os.ReadDir(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.HasSuffix(entry.Name(), ".reserving") {
+			t.Fatalf("reservation sidecar left after rotate: %s", entry.Name())
+		}
+	}
+}
+
 func TestLogRotator_SameSecondBackupNames(t *testing.T) {
 	tempDir := t.TempDir()
 	logFile := filepath.Join(tempDir, "test.log")
@@ -230,6 +253,7 @@ func TestUniqueBackupPathSkipsCompressedSibling(t *testing.T) {
 	if got != want {
 		t.Fatalf("got %s, want %s", got, want)
 	}
+	assertReservedBackupName(t, got)
 }
 
 func TestUniqueBackupPathMoreThan100Candidates(t *testing.T) {
@@ -255,6 +279,7 @@ func TestUniqueBackupPathMoreThan100Candidates(t *testing.T) {
 	if got != want {
 		t.Fatalf("got %s, want %s", got, want)
 	}
+	assertReservedBackupName(t, got)
 }
 
 func TestUniqueBackupPathErrorWhenDirMissing(t *testing.T) {
@@ -300,8 +325,85 @@ func TestUniqueBackupPathReservesExclusively(t *testing.T) {
 			t.Fatalf("duplicate reserved path %s", p)
 		}
 		seen[p] = struct{}{}
-		if _, err := os.Stat(p); err != nil {
-			t.Fatalf("reserved file missing: %v", err)
+		assertReservedBackupName(t, p)
+	}
+}
+
+func assertReservedBackupName(t *testing.T, backupPath string) {
+	t.Helper()
+	if _, err := os.Stat(backupPath); !os.IsNotExist(err) {
+		t.Fatalf("final backup path %s should not exist until rename: %v", backupPath, err)
+	}
+	if _, err := os.Stat(backupReservationPath(backupPath)); err != nil {
+		t.Fatalf("reservation sidecar missing for %s: %v", backupPath, err)
+	}
+}
+
+func TestCleanupIgnoresReservationSidecarsAndTempGzip(t *testing.T) {
+	tempDir := t.TempDir()
+	logFile := filepath.Join(tempDir, "test.log")
+	sidecar := filepath.Join(tempDir, "test-20260910-120000.log.reserving")
+	tmpGz := filepath.Join(tempDir, "test-20260910-120000.log.gz.tmp.1234")
+	if err := os.WriteFile(sidecar, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tmpGz, []byte("partial"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	lr := NewLogRotator(&LogRotateConfig{MaxSize: 1, MaxBackups: 1, MaxAge: 1, Compress: false})
+	if err := os.WriteFile(logFile, []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := lr.CheckAndRotate(logFile); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range []string{sidecar, tmpGz} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("in-progress file %s was removed: %v", path, err)
+		}
+	}
+
+	backups, err := lr.GetBackupFiles(logFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(backups) != 1 {
+		t.Fatalf("expected 1 real backup, got %d (%v)", len(backups), backups)
+	}
+	for _, path := range backups {
+		if path == sidecar || path == tmpGz {
+			t.Fatalf("in-progress file %s was treated as a backup", path)
+		}
+	}
+}
+
+type failReader struct{}
+
+func (failReader) Read([]byte) (int, error) {
+	return 0, fmt.Errorf("forced read failure")
+}
+
+func TestCompressFileFailureLeavesNoPartialGz(t *testing.T) {
+	tempDir := t.TempDir()
+	dst := filepath.Join(tempDir, "src.log.gz")
+
+	lr := NewLogRotator(nil)
+	if err := lr.compressReader(failReader{}, dst); err == nil {
+		t.Fatal("expected compression to fail")
+	}
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Fatalf("partial gzip file was left at %s: %v", dst, err)
+	}
+
+	entries, err := os.ReadDir(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if strings.Contains(entry.Name(), ".tmp.") {
+			t.Fatalf("temporary gzip file was left: %s", entry.Name())
 		}
 	}
 }

--- a/pkg/logrotate_test.go
+++ b/pkg/logrotate_test.go
@@ -430,6 +430,34 @@ func TestCleanupRemovesStaleReservationAndTempGzip(t *testing.T) {
 	}
 }
 
+func TestCleanupCollapsesRawAndGzipOfSameRotation(t *testing.T) {
+	tempDir := t.TempDir()
+	logFile := filepath.Join(tempDir, "test.log")
+	raw := filepath.Join(tempDir, "test-20260910-120000.log")
+	gz := filepath.Join(tempDir, "test-20260910-120000.log.gz")
+	if err := os.WriteFile(raw, []byte("raw"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(gz, []byte("gz"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lr := NewLogRotator(&LogRotateConfig{MaxSize: 1, MaxBackups: 5, MaxAge: 3650, Compress: false})
+	if err := os.WriteFile(logFile, []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := lr.CheckAndRotate(logFile); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(raw); !os.IsNotExist(err) {
+		t.Fatalf("raw backup should be dropped when .gz exists: %v", err)
+	}
+	if _, err := os.Stat(gz); err != nil {
+		t.Fatalf("compressed backup was removed: %v", err)
+	}
+}
+
 func TestCleanupUsesFilenameStampNotMtime(t *testing.T) {
 	tempDir := t.TempDir()
 	logFile := filepath.Join(tempDir, "test.log")

--- a/pkg/logrotate_test.go
+++ b/pkg/logrotate_test.go
@@ -167,6 +167,41 @@ func TestLogRotator_Compression(t *testing.T) {
 	}
 }
 
+func TestRemoveIdleLockLeavesHeldLock(t *testing.T) {
+	tempDir := t.TempDir()
+	lockPath := filepath.Join(tempDir, "test.log.rotate.lock")
+	held, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer held.Close()
+	if err := syscall.Flock(int(held.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatal(err)
+	}
+	defer syscall.Flock(int(held.Fd()), syscall.LOCK_UN)
+
+	if err := RemoveIdleLock(lockPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(lockPath); err != nil {
+		t.Fatalf("held lock was removed: %v", err)
+	}
+}
+
+func TestRemoveIdleLockRemovesUnlockedLock(t *testing.T) {
+	tempDir := t.TempDir()
+	lockPath := filepath.Join(tempDir, "test.log.rotate.lock")
+	if err := os.WriteFile(lockPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveIdleLock(lockPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("idle lock was kept: %v", err)
+	}
+}
+
 func TestRotateWaitsForPerLogLock(t *testing.T) {
 	tempDir := t.TempDir()
 	logFile := filepath.Join(tempDir, "test.log")

--- a/pkg/logrotate_test.go
+++ b/pkg/logrotate_test.go
@@ -339,7 +339,7 @@ func assertReservedBackupName(t *testing.T, backupPath string) {
 	}
 }
 
-func TestCleanupIgnoresReservationSidecarsAndTempGzip(t *testing.T) {
+func TestCleanupRemovesStaleReservationAndTempGzip(t *testing.T) {
 	tempDir := t.TempDir()
 	logFile := filepath.Join(tempDir, "test.log")
 	sidecar := filepath.Join(tempDir, "test-20260910-120000.log.reserving")
@@ -360,8 +360,8 @@ func TestCleanupIgnoresReservationSidecarsAndTempGzip(t *testing.T) {
 	}
 
 	for _, path := range []string{sidecar, tmpGz} {
-		if _, err := os.Stat(path); err != nil {
-			t.Fatalf("in-progress file %s was removed: %v", path, err)
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("stale rotation file %s was not removed: %v", path, err)
 		}
 	}
 
@@ -372,10 +372,29 @@ func TestCleanupIgnoresReservationSidecarsAndTempGzip(t *testing.T) {
 	if len(backups) != 1 {
 		t.Fatalf("expected 1 real backup, got %d (%v)", len(backups), backups)
 	}
-	for _, path := range backups {
-		if path == sidecar || path == tmpGz {
-			t.Fatalf("in-progress file %s was treated as a backup", path)
-		}
+}
+
+func TestCleanupUsesFilenameStampNotMtime(t *testing.T) {
+	tempDir := t.TempDir()
+	logFile := filepath.Join(tempDir, "test.log")
+	oldBackup := filepath.Join(tempDir, "test-20200101-000000.log")
+	if err := os.WriteFile(oldBackup, []byte("old"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(oldBackup, time.Now(), time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	lr := NewLogRotator(&LogRotateConfig{MaxSize: 1, MaxBackups: 5, MaxAge: 1, Compress: false})
+	if err := os.WriteFile(logFile, []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := lr.CheckAndRotate(logFile); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(oldBackup); !os.IsNotExist(err) {
+		t.Fatalf("backup with old rotation stamp was kept despite recent mtime: %v", err)
 	}
 }
 

--- a/pkg/logrotate_test.go
+++ b/pkg/logrotate_test.go
@@ -2,9 +2,11 @@ package pkg
 
 import (
 	"compress/gzip"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
@@ -208,6 +210,99 @@ func TestLogRotator_BackupMatchingIgnoresUnrelatedFiles(t *testing.T) {
 	}
 	if len(backups) != 1 {
 		t.Fatalf("expected 1 backup, got %d (%v)", len(backups), backups)
+	}
+}
+
+func TestUniqueBackupPathSkipsCompressedSibling(t *testing.T) {
+	tempDir := t.TempDir()
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	timestamp := now.Format("20060102-150405")
+	gz := filepath.Join(tempDir, fmt.Sprintf("test-%s.log.gz", timestamp))
+	if err := os.WriteFile(gz, []byte("compressed"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := uniqueBackupPathAt(tempDir, "test", ".log", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(tempDir, fmt.Sprintf("test-%s-1.log", timestamp))
+	if got != want {
+		t.Fatalf("got %s, want %s", got, want)
+	}
+}
+
+func TestUniqueBackupPathMoreThan100Candidates(t *testing.T) {
+	tempDir := t.TempDir()
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	timestamp := now.Format("20060102-150405")
+	for i := 0; i <= 100; i++ {
+		suffix := timestamp
+		if i > 0 {
+			suffix = fmt.Sprintf("%s-%d", timestamp, i)
+		}
+		path := filepath.Join(tempDir, fmt.Sprintf("test-%s.log", suffix))
+		if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := uniqueBackupPathAt(tempDir, "test", ".log", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(tempDir, fmt.Sprintf("test-%s-101.log", timestamp))
+	if got != want {
+		t.Fatalf("got %s, want %s", got, want)
+	}
+}
+
+func TestUniqueBackupPathErrorWhenDirMissing(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing")
+	_, err := uniqueBackupPathAt(missing, "test", ".log", time.Now())
+	if err == nil {
+		t.Fatal("expected error for missing backup directory")
+	}
+}
+
+func TestUniqueBackupPathReservesExclusively(t *testing.T) {
+	tempDir := t.TempDir()
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	const n = 50
+
+	paths := make([]string, n)
+	errCh := make(chan error, n)
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			p, err := uniqueBackupPathAt(tempDir, "test", ".log", now)
+			if err != nil {
+				errCh <- err
+				return
+			}
+			paths[i] = p
+		}(i)
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatal(err)
+	}
+
+	seen := make(map[string]struct{}, n)
+	for _, p := range paths {
+		if p == "" {
+			t.Fatal("empty reserved path")
+		}
+		if _, dup := seen[p]; dup {
+			t.Fatalf("duplicate reserved path %s", p)
+		}
+		seen[p] = struct{}{}
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("reserved file missing: %v", err)
+		}
 	}
 }
 

--- a/pkg/logrotate_test.go
+++ b/pkg/logrotate_test.go
@@ -54,6 +54,9 @@ func TestLogRotator_CheckAndRotate(t *testing.T) {
 	if err := lr.CheckAndRotate(logFile); err != nil {
 		t.Errorf("unexpected error for non-existent file: %v", err)
 	}
+	if _, err := os.Stat(logRotateLockPath(logFile)); !os.IsNotExist(err) {
+		t.Fatalf("missing log should not create a rotation lock: %v", err)
+	}
 
 	// Case 2: File small
 	os.WriteFile(logFile, []byte("small"), 0644)
@@ -82,6 +85,18 @@ func TestLogRotator_CheckAndRotate(t *testing.T) {
 	}
 	if len(backups) != 1 {
 		t.Errorf("expected 1 backup, got %d", len(backups))
+	}
+}
+
+func TestForceRotateMissingFileDoesNotCreateLock(t *testing.T) {
+	tempDir := t.TempDir()
+	logFile := filepath.Join(tempDir, "missing.log")
+	lr := NewLogRotator(&LogRotateConfig{MaxAge: 1})
+	if err := lr.ForceRotate(logFile); err != nil {
+		t.Fatalf("ForceRotate missing file: %v", err)
+	}
+	if _, err := os.Stat(logRotateLockPath(logFile)); !os.IsNotExist(err) {
+		t.Fatalf("missing log should not create a rotation lock: %v", err)
 	}
 }
 

--- a/pkg/logrotate_test.go
+++ b/pkg/logrotate_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -148,6 +149,46 @@ func TestLogRotator_Compression(t *testing.T) {
 		t.Errorf("expected 1 backup, got %d", len(backups))
 	} else if filepath.Ext(backups[0]) != ".gz" {
 		t.Errorf("expected backup to have .gz extension, got %s", filepath.Ext(backups[0]))
+	}
+}
+
+func TestRotateWaitsForPerLogLock(t *testing.T) {
+	tempDir := t.TempDir()
+	logFile := filepath.Join(tempDir, "test.log")
+	if err := os.WriteFile(logFile, []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lock, err := os.OpenFile(logRotateLockPath(logFile), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lock.Close()
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		lr := NewLogRotator(&LogRotateConfig{MaxSize: 1, MaxBackups: 5, MaxAge: 1, Compress: false})
+		done <- lr.CheckAndRotate(logFile)
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("rotation finished while lock was held: %v", err)
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	if err := syscall.Flock(int(lock.Fd()), syscall.LOCK_UN); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("rotation did not proceed after lock was released")
 	}
 }
 

--- a/renovate.json
+++ b/renovate.json
@@ -5,30 +5,35 @@
     "group:allNonMajor",
     "group:githubArtifactActions",
     "group:linters",
-    "security:openssf-scorecard"
+    "security:openssf-scorecard",
+    ":automergeStableNonMajor",
+    ":automergeDigest",
+    ":automergeBranch"
   ],
   "env": {
     "GOPROXY": "https://golang.flatt.tech"
   },
-  "gomod": {
-    "managerFilePatterns": ["/(^|/)go\\.mod$/"]
-  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^internal\\/zsh\\/integration_test\\.go$/"],
+      "matchStrings": [
+        "const zshAutosuggestionsTag = \"(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)\""
+      ],
+      "depNameTemplate": "zsh-users/zsh-autosuggestions",
+      "datasourceTemplate": "github-tags",
+      "versioningTemplate": "semver-coerced"
+    }
+  ],
   "packageRules": [
     {
       "matchPackageNames": ["*"],
-      "minimumReleaseAge": "3 days",
-      "internalChecksFilter": "strict"
-    },
-    {
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchCurrentVersion": "!/^0/",
-      "automerge": true
+      "minimumReleaseAge": "3 days"
     },
     {
       "matchUpdateTypes": ["digest"],
       "matchDatasources": ["docker"],
-      "minimumReleaseAge": null,
-      "automerge": true
+      "minimumReleaseAge": null
     },
     {
       "matchDatasources": ["go"],
@@ -36,10 +41,6 @@
       "minimumReleaseAge": null
     }
   ],
-  "automergeType": "branch",
-  "postUpdateOptions": [
-    "gomodMassage",
-    "gomodTidy"
-  ],
+  "postUpdateOptions": ["gomodMassage", "gomodTidy"],
   "timezone": "Asia/Shanghai"
 }

--- a/smart-suggestion.plugin.zsh
+++ b/smart-suggestion.plugin.zsh
@@ -161,11 +161,13 @@ function _fetch_suggestions() {
     local scrollback_file_args=()
     [[ -n "$scrollback_file" ]] && scrollback_file_args=(--scrollback-file "$scrollback_file")
 
-    # Call the Go binary with proper arguments
-    SMART_SUGGESTION_ALIASES="$shell_aliases" \
-    SMART_SUGGESTION_COMMANDS="$available_commands" \
-    SMART_SUGGESTION_HISTORY="$shell_history" \
-    "$SMART_SUGGESTION_BINARY" \
+    # exec so $! is the Go binary, not a zsh wrapper. Ctrl-C can then
+    # cancel the actual API request.
+    export SMART_SUGGESTION_ALIASES="$shell_aliases"
+    export SMART_SUGGESTION_COMMANDS="$available_commands"
+    export SMART_SUGGESTION_HISTORY="$shell_history"
+
+    exec "$SMART_SUGGESTION_BINARY" \
         --provider "$SMART_SUGGESTION_AI_PROVIDER" \
         --input "$input" \
         --output - \
@@ -174,8 +176,6 @@ function _fetch_suggestions() {
         $debug_flag \
         $context_flag \
         2> "$error_file"
-
-    return $?
 }
 
 

--- a/smart-suggestion.plugin.zsh
+++ b/smart-suggestion.plugin.zsh
@@ -336,11 +336,8 @@ function _check_smart_suggestion_updates() {
         if [[ -f "$update_file" ]]; then
             local last_check
             last_check=$(<"$update_file" 2>/dev/null)
-            if [[ "$last_check" =~ ^[0-9]+$ ]]; then
-                local time_diff=$((current_time - last_check))
-                if (( time_diff < update_interval )); then
-                    return 0
-                fi
+            if [[ "$last_check" =~ ^[0-9]+$ ]] && (( current_time - last_check < update_interval )); then
+                return 0
             fi
         fi
 

--- a/smart-suggestion.plugin.zsh
+++ b/smart-suggestion.plugin.zsh
@@ -220,7 +220,8 @@ function _do_smart_suggestion() {
     local canceled_file="${SMART_SUGGESTION_CACHE_DIR}/canceled.$$"
     local error_file="${SMART_SUGGESTION_CACHE_DIR}/error.$$"
     local out_file="${SMART_SUGGESTION_CACHE_DIR}/suggest.$$"
-    rm -f "$canceled_file" "$error_file" "$out_file"
+    local temp_files=("$canceled_file" "$error_file" "$out_file")
+    rm -f "${temp_files[@]}"
 
     local scrollback_file=""
 
@@ -263,7 +264,7 @@ function _do_smart_suggestion() {
 
     if [[ -f "$canceled_file" ]]; then
         _zsh_autosuggest_clear
-        rm -f "$canceled_file" "$error_file" "$out_file"
+        rm -f "${temp_files[@]}"
         return 1
     fi
 
@@ -278,7 +279,7 @@ function _do_smart_suggestion() {
         if [[ -s "$error_file" ]]; then
             error_msg=$(<"$error_file")
         fi
-        rm -f "$canceled_file" "$error_file" "$out_file"
+        rm -f "${temp_files[@]}"
         if [[ -z "${error_msg//[[:space:]]/}" ]]; then
             error_msg="No suggestion available at this time. Please try again later."
         fi
@@ -287,7 +288,7 @@ function _do_smart_suggestion() {
         print -r -u2 -- "$error_msg"
         return 1
     fi
-    rm -f "$canceled_file" "$error_file" "$out_file"
+    rm -f "${temp_files[@]}"
 
     ##### Process response
 

--- a/smart-suggestion.plugin.zsh
+++ b/smart-suggestion.plugin.zsh
@@ -51,10 +51,12 @@ if [[ -z "$SMART_SUGGESTION_AI_PROVIDER" ]]; then
 fi
 
 : ${SMART_SUGGESTION_CACHE_DIR:="${XDG_CACHE_HOME:-$HOME/.cache}/smart-suggestion"}
-mkdir -p "$SMART_SUGGESTION_CACHE_DIR"
+(umask 077; mkdir -p "$SMART_SUGGESTION_CACHE_DIR") || return 1
+chmod 700 "$SMART_SUGGESTION_CACHE_DIR" || return 1
 
 if [[ "$SMART_SUGGESTION_DEBUG" == 'true' ]]; then
-    touch "${SMART_SUGGESTION_CACHE_DIR}/debug.log"
+    (umask 077; touch "${SMART_SUGGESTION_CACHE_DIR}/debug.log") || return 1
+    chmod 600 "${SMART_SUGGESTION_CACHE_DIR}/debug.log" || return 1
 fi
 
 # Detect binary path
@@ -139,6 +141,7 @@ function _smart_suggestion_shell_history() {
 
 function _fetch_suggestions() {
     local scrollback_file="$1"
+    local error_file="$2"
 
     # Source config file and export all variables
     _smart_suggestion_source_config
@@ -170,7 +173,7 @@ function _fetch_suggestions() {
         "${scrollback_file_args[@]}" \
         $debug_flag \
         $context_flag \
-        2> "${SMART_SUGGESTION_CACHE_DIR}/error"
+        2> "$error_file"
 
     return $?
 }
@@ -178,6 +181,7 @@ function _fetch_suggestions() {
 
 function _show_loading_animation() {
     local pid=$1
+    local canceled_file=$2
     local interval=0.1
     local animation_chars=("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")
     local i=1
@@ -186,7 +190,7 @@ function _show_loading_animation() {
         kill $pid 2>/dev/null
         # Clear the line and restore cursor
         tput -S <<<"cr el cnorm"
-        touch "${SMART_SUGGESTION_CACHE_DIR}/canceled"
+        touch "$canceled_file"
     }
     trap cleanup SIGINT EXIT
 
@@ -212,8 +216,11 @@ function _show_loading_animation() {
 
 function _do_smart_suggestion() {
     ##### Get input
-    rm -f "${SMART_SUGGESTION_CACHE_DIR}/canceled"
-    rm -f "${SMART_SUGGESTION_CACHE_DIR}/error"
+    setopt localoptions nomonitor
+    local canceled_file="${SMART_SUGGESTION_CACHE_DIR}/canceled.$$"
+    local error_file="${SMART_SUGGESTION_CACHE_DIR}/error.$$"
+    local out_file="${SMART_SUGGESTION_CACHE_DIR}/suggest.$$"
+    rm -f "$canceled_file" "$error_file" "$out_file"
 
     local scrollback_file=""
 
@@ -232,10 +239,13 @@ function _do_smart_suggestion() {
     _zsh_autosuggest_clear
 
     ##### Fetch message
-    exec {OUTPUT_FD}< <(_fetch_suggestions "$scrollback_file" & echo $!)
-    read pid <&$OUTPUT_FD
+    # Write the suggestion to a per-shell temp file so the worker PID is not
+    # mixed into stdout (numeric replies like "=42" were being read as the PID).
+    _fetch_suggestions "$scrollback_file" "$error_file" > "$out_file" &
+    local pid=$!
 
-    _show_loading_animation $pid
+    _show_loading_animation $pid "$canceled_file"
+    wait $pid 2>/dev/null
     local response_code=$?
 
     # Ensure cursor is visible and line is cleared after animation
@@ -251,21 +261,24 @@ function _do_smart_suggestion() {
         fi
     fi
 
-    if [[ -f "${SMART_SUGGESTION_CACHE_DIR}/canceled" ]]; then
+    if [[ -f "$canceled_file" ]]; then
         _zsh_autosuggest_clear
+        rm -f "$canceled_file" "$error_file" "$out_file"
         return 1
     fi
 
-    local message
-    read -u $OUTPUT_FD -d '' message || true
-    exec {OUTPUT_FD}<&-
+    local message=""
+    if [[ -f "$out_file" ]]; then
+        read -r -d '' message < "$out_file" || true
+    fi
 
     if [[ -z "$message" ]]; then
         _zsh_autosuggest_clear
         local error_msg
-        if [[ -s "${SMART_SUGGESTION_CACHE_DIR}/error" ]]; then
-            error_msg=$(<"${SMART_SUGGESTION_CACHE_DIR}/error")
+        if [[ -s "$error_file" ]]; then
+            error_msg=$(<"$error_file")
         fi
+        rm -f "$canceled_file" "$error_file" "$out_file"
         if [[ -z "${error_msg//[[:space:]]/}" ]]; then
             error_msg="No suggestion available at this time. Please try again later."
         fi
@@ -274,6 +287,7 @@ function _do_smart_suggestion() {
         print -r -u2 -- "$error_msg"
         return 1
     fi
+    rm -f "$canceled_file" "$error_file" "$out_file"
 
     ##### Process response
 

--- a/smart-suggestion.plugin.zsh
+++ b/smart-suggestion.plugin.zsh
@@ -180,19 +180,18 @@ function _fetch_suggestions() {
 
 
 function _show_loading_animation() {
+    setopt localoptions localtraps
     local pid=$1
     local canceled_file=$2
     local interval=0.1
     local animation_chars=("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")
     local i=1
 
-    cleanup() {
+    trap '
         kill $pid 2>/dev/null
-        # Clear the line and restore cursor
         tput -S <<<"cr el cnorm"
         touch "$canceled_file"
-    }
-    trap cleanup SIGINT EXIT
+    ' INT EXIT
 
     tput -S <<<"sc civis"
     while kill -0 $pid 2>/dev/null; do
@@ -211,7 +210,7 @@ function _show_loading_animation() {
 
     # Always clean up when the loop exits
     tput -S <<<"cr el cnorm"
-    trap - SIGINT EXIT
+    trap - INT EXIT
 }
 
 function _do_smart_suggestion() {
@@ -311,6 +310,7 @@ function _do_smart_suggestion() {
 }
 
 function _check_smart_suggestion_updates() {
+    setopt localoptions localtraps
     [[ -x "$SMART_SUGGESTION_BINARY" ]] || return 0
 
     # Validate interval is a positive integer

--- a/smart-suggestion.plugin.zsh
+++ b/smart-suggestion.plugin.zsh
@@ -313,6 +313,8 @@ function _do_smart_suggestion() {
 function _check_smart_suggestion_updates() {
     setopt localoptions localtraps
     [[ -x "$SMART_SUGGESTION_BINARY" ]] || return 0
+    zmodload zsh/system 2>/dev/null || return 0
+    zsystem supports flock || return 0
 
     # Validate interval is a positive integer
     if [[ ! "$SMART_SUGGESTION_UPDATE_INTERVAL" =~ ^[0-9]+$ ]] || (( SMART_SUGGESTION_UPDATE_INTERVAL <= 0 )); then
@@ -320,41 +322,38 @@ function _check_smart_suggestion_updates() {
     fi
 
     local update_file="${SMART_SUGGESTION_CACHE_DIR}/last_update_check"
-    local lockdir="${SMART_SUGGESTION_CACHE_DIR}/update_check.lock"
+    local lockfile="${SMART_SUGGESTION_CACHE_DIR}/update_check.lock"
     local current_time=$(date +%s)
     local update_interval=$((SMART_SUGGESTION_UPDATE_INTERVAL * 24 * 3600))
 
-    # Cheap lock using mkdir (atomic operation)
-    mkdir "$lockdir" 2>/dev/null || return 0
-    trap 'rmdir "$lockdir" 2>/dev/null' EXIT
+    # Recover leftover mkdir lock dirs from older plugin versions.
+    [[ -d "$lockfile" ]] && rmdir "$lockfile" 2>/dev/null
+    : >> "$lockfile" 2>/dev/null || return 0
 
-    # Check if we should check for updates
-    if [[ -f "$update_file" ]]; then
-        local last_check
-        last_check=$(<"$update_file" 2>/dev/null)
-        # Validate last_check is a number
-        if [[ "$last_check" =~ ^[0-9]+$ ]]; then
-            local time_diff=$((current_time - last_check))
-            if (( time_diff < update_interval )); then
-                rmdir "$lockdir" 2>/dev/null
-                trap - EXIT
-                return 0
+    local lock_fd
+    zsystem flock -t 0 -f lock_fd "$lockfile" || return 0
+    {
+        if [[ -f "$update_file" ]]; then
+            local last_check
+            last_check=$(<"$update_file" 2>/dev/null)
+            if [[ "$last_check" =~ ^[0-9]+$ ]]; then
+                local time_diff=$((current_time - last_check))
+                if (( time_diff < update_interval )); then
+                    return 0
+                fi
             fi
         fi
-    fi
 
-    # Update the last check time
-    print -r -- "$current_time" >| "$update_file" 2>/dev/null
+        print -r -- "$current_time" >| "$update_file" 2>/dev/null
 
-    # Check for updates in background, write flag file instead of printing
-    {
-        if "$SMART_SUGGESTION_BINARY" update --check-only >/dev/null 2>&1; then
-            : >| "${SMART_SUGGESTION_CACHE_DIR}/update_available"
-        fi
-    } &!
-
-    rmdir "$lockdir" 2>/dev/null
-    trap - EXIT
+        {
+            if "$SMART_SUGGESTION_BINARY" update --check-only >/dev/null 2>&1; then
+                : >| "${SMART_SUGGESTION_CACHE_DIR}/update_available"
+            fi
+        } &!
+    } always {
+        zsystem flock -u $lock_fd
+    }
 }
 
 function _smart_suggestion_update_notify() {

--- a/smart-suggestion.plugin.zsh
+++ b/smart-suggestion.plugin.zsh
@@ -51,6 +51,7 @@ if [[ -z "$SMART_SUGGESTION_AI_PROVIDER" ]]; then
 fi
 
 : ${SMART_SUGGESTION_CACHE_DIR:="${XDG_CACHE_HOME:-$HOME/.cache}/smart-suggestion"}
+export SMART_SUGGESTION_CACHE_DIR
 (umask 077; mkdir -p "$SMART_SUGGESTION_CACHE_DIR") || return 1
 chmod 700 "$SMART_SUGGESTION_CACHE_DIR" || return 1
 
@@ -377,6 +378,7 @@ function smart-suggestion() {
     echo "    - SMART_SUGGESTION_AUTO_UPDATE: Enable automatic update checking (default: true, value: $SMART_SUGGESTION_AUTO_UPDATE)."
     echo "    - SMART_SUGGESTION_UPDATE_INTERVAL: Days between update checks (default: 7, value: $SMART_SUGGESTION_UPDATE_INTERVAL)."
     echo "    - SMART_SUGGESTION_BINARY: Path to the smart-suggestion binary (value: $SMART_SUGGESTION_BINARY)."
+    echo "    - SMART_SUGGESTION_CACHE_DIR: Cache directory for logs and state (default: ~/.cache/smart-suggestion, value: $SMART_SUGGESTION_CACHE_DIR)."
 }
 
 zle -N _do_smart_suggestion


### PR DESCRIPTION
Supersedes #20.

A simpler alternative to #20 that fixes the same defects without FIFO/`mktemp -d` request directories.

## What changed

- Keep log rotation backups unique within the same second and match only timestamped backups generated by the rotator.
- Check the gzip writer `Close()` error so rotated archives are valid.
- Restrict `debug.log` and the cache directory to `0600`/`0700`, including existing installations.
- Isolate suggestion stdout from the worker PID by writing to per-shell temp files (`suggest.$$`, `error.$$`, `canceled.$$`) so numeric replies like `=42` are not consumed as a PID.
- Pin the zsh-autosuggestions clone used by plugin tests to `v0.7.1`, with a Renovate regex manager to update that tag.
- Replace hand-written Renovate automerge rules with official presets.
- Reserve backup names with a `.reserving` sidecar so `uniqueBackupPath()` cannot collide on rename, keep allocating suffixes past 100 candidates, and never expose a zero-byte final backup to cleanup.
- Write gzip archives to a temp file in the destination directory and rename only after `Close()` succeeds so a failed compress cannot leave a partial `.gz` that cleanup treats as a real backup, and so the rename cannot fail with `EXDEV`.
- Age and rank backups from the filename rotation stamp instead of mtime, and delete leftover `.reserving` / `.gz.tmp.*` files on the next cleanup.
- Serialize rotate → compress → cleanup with a per-log exclusive flock so leftover temp files are never deleted while another process is rotating the same log.
- Share that flock with the proxy writer, which reopens its log fd after rename so `rotate-logs` is safe against a live session log. Missing logs are not locked, and lock open failures no longer fall back to unlocked rotation.
- `exec` the suggestion binary so Ctrl-C cancels the real Go request, take a shared flock while reading proxy scrollback, close reopened log fds, collapse raw+`.gz` pairs into one backup, and skip live session logs in old-session cleanup.
- Always take the shared read lock before opening a log, keep session process-lock inodes instead of unlinking them, and derive session lock paths from the base log so extensionless `--log-file` names stay live.
- Keep plugin INT/EXIT traps function-local so suggestion and update checks do not clobber the user's handlers. Leave `.rotate.lock` and session `.lock` files on disk; unlinking them after exclusive flock still races with a waiter that already opened the inode.
- Honor `SMART_SUGGESTION_CACHE_DIR` in the Go binary so proxy logs, debug.log, and suggestion context use the same cache directory as the plugin.
- Use `zsystem flock` for auto-update checks so SIGKILL/crash cannot leave a stuck `mkdir` lock directory, and recover leftover lock dirs from older plugin versions.

## Why

These are confirmed defects on `main`. #20 stacked a heavier FIFO/`mktemp` design on `feat/migrate-any-llm-go`; this PR targets `main` with a smaller change.

https://ampcode.com/threads/T-01a0870d-c54a-724a-8a05-e14a16acfe44
https://ampcode.com/threads/T-01a0890a-263a-76c9-a5a4-093f8e0ecc30